### PR TITLE
Handle SteamCMD errors properly

### DIFF
--- a/SCMM.Steam.Abstractions/ISteamConsoleClient.cs
+++ b/SCMM.Steam.Abstractions/ISteamConsoleClient.cs
@@ -4,5 +4,5 @@ namespace SCMM.Steam.Abstractions;
 
 public interface ISteamConsoleClient
 {
-    Task<WebFileData> DownloadWorkshopFile(string appId, string workshopFileId);
+    Task<WebFileData> DownloadWorkshopFile(string appId, string workshopFileId, bool clearCache = true);
 }


### PR DESCRIPTION
# Changes
- Clear the SteamCMD cache before downloading workshop files. This fixes the temporary "Failure" error.
- Flag workshop files as permanently unavailable if SteamCMD returns "Access Denied" or "File Not Found" errors.

Refs #22
