### PR TITLE
Store page now shows all items in the "all items of [type]" popup dialog

### DIFF
--- a/SCMM.Web.Client/Pages/Store/StorePage.razor
+++ b/SCMM.Web.Client/Pages/Store/StorePage.razor
@@ -822,8 +822,8 @@ else
     {
         Dialogs.Show<ViewItemListDialog>(null, parameters: new DialogParameters()
         {
-            ["ListName"] = $"Marketable {item.ItemType.Pluralise()}",
-            ["ListUrl"] = $"api/item?id={item.AssetDescriptionId}&type={item.ItemType}&marketable=true&count=-1",
+            ["ListName"] = $"All {item.ItemType.Pluralise()}",
+            ["ListUrl"] = $"api/item?id={item.AssetDescriptionId}&type={item.ItemType}&count=-1",
             ["DemandUrl"] = $"api/item/type/{item.ItemType}/demand",
             ["HighlightedItemId"] = item.AssetDescriptionId,
             ["SortBy"] = nameof(ItemDescriptionWithPriceDTO.TimeAccepted),


### PR DESCRIPTION
Store page now shows all items in the "all items of [type]" popup dialog.

![image](https://github.com/Steam-Community-Market-Manager/SCMM/assets/123988/cac9d8eb-8a92-473c-8d40-e2dc2f378210)

Closes #46