### PR TITLE
User customisable market types

### DIFF
--- a/SCMM.Discord.Bot.Server/SCMM.Discord.Bot.Server.csproj
+++ b/SCMM.Discord.Bot.Server/SCMM.Discord.Bot.Server.csproj
@@ -8,10 +8,10 @@
   <ItemGroup>
     <PackageReference Include="CommandQuery.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.14" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.15" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.16.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SCMM.Google.Client/SCMM.Google.Client.csproj
+++ b/SCMM.Google.Client/SCMM.Google.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.64.0.3205" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.65.0.3205" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
   </ItemGroup>

--- a/SCMM.Shared.Web.Client.Tests/SCMM.Shared.Web.Client.Tests.csproj
+++ b/SCMM.Shared.Web.Client.Tests/SCMM.Shared.Web.Client.Tests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.6.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/SCMM.Shared.Web.Client/SCMM.Shared.Web.Client.csproj
+++ b/SCMM.Shared.Web.Client/SCMM.Shared.Web.Client.csproj
@@ -9,7 +9,7 @@
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
 	<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
 	<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-	<PackageReference Include="Polly" Version="8.2.0" />
+	<PackageReference Include="Polly" Version="8.2.1" />
 	<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>
 

--- a/SCMM.Shared.Web.Server/SCMM.Shared.Web.Server.csproj
+++ b/SCMM.Shared.Web.Server/SCMM.Shared.Web.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />

--- a/SCMM.Steam.API/SCMM.Steam.API.csproj
+++ b/SCMM.Steam.API/SCMM.Steam.API.csproj
@@ -10,7 +10,7 @@
 	<PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="CommandQuery" Version="1.0.0" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
-	<PackageReference Include="SixLabors.ImageSharp" Version="3.1.1" />
+	<PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.0" />
 	<PackageReference Include="SixLabors.Fonts" Version="2.0.1" />
   </ItemGroup>

--- a/SCMM.Steam.Client/SCMM.Steam.Client.csproj
+++ b/SCMM.Steam.Client/SCMM.Steam.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.55" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.57" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />

--- a/SCMM.Steam.Data.Models/Attributes/BuyFromAttribute.cs
+++ b/SCMM.Steam.Data.Models/Attributes/BuyFromAttribute.cs
@@ -8,10 +8,6 @@ public class BuyFromAttribute : Attribute
 {
     public string Url { get; set; }
 
-    public string AffiliateCode { get; set; }
-
-    public bool HasAffiliateProgram => !String.IsNullOrEmpty(AffiliateCode);
-
     public PriceTypes AcceptedPaymentTypes { get; set; }
 
     public float DiscountMultiplier { get; set; }

--- a/SCMM.Steam.Data.Models/Attributes/MarketAttribute.cs
+++ b/SCMM.Steam.Data.Models/Attributes/MarketAttribute.cs
@@ -13,4 +13,6 @@ public class MarketAttribute : Attribute
     public bool IsFirstParty { get; set; }
 
     public string Color { get; set; }
+
+    public string AffiliateUrl { get; set; }
 }

--- a/SCMM.Steam.Data.Models/Attributes/MarketAttribute.cs
+++ b/SCMM.Steam.Data.Models/Attributes/MarketAttribute.cs
@@ -10,5 +10,7 @@ public class MarketAttribute : Attribute
 
     public ulong[] SupportedAppIds { get; set; }
 
+    public bool IsFirstParty { get; set; }
+
     public string Color { get; set; }
 }

--- a/SCMM.Steam.Data.Models/Attributes/SellToAttribute.cs
+++ b/SCMM.Steam.Data.Models/Attributes/SellToAttribute.cs
@@ -8,10 +8,6 @@ public class SellToAttribute : Attribute
 {
     public string Url { get; set; }
 
-    public string AffiliateCode { get; set; }
-
-    public bool HasAffiliateProgram => !String.IsNullOrEmpty(AffiliateCode);
-
     public PriceTypes AcceptedPaymentTypes { get; set; }
 
     public long FeeSurcharge { get; set; }

--- a/SCMM.Steam.Data.Models/Enums/MarketType.cs
+++ b/SCMM.Steam.Data.Models/Enums/MarketType.cs
@@ -23,8 +23,8 @@ namespace SCMM.Steam.Data.Models.Enums
         SteamCommunityMarket = 2,
 
         [Display(Name = "Skinport")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#FA490A")]
-        [BuyFrom(Url = "https://skinport.com/{1}/market?r=scmm&item={3}", AffiliateCode = "scmm", AcceptedPaymentTypes = PriceTypes.Cash)]
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#FA490A", AffiliateUrl = "https://skinport.com/r/scmm")]
+        [BuyFrom(Url = "https://skinport.com/{1}/market?r=scmm&item={3}", AcceptedPaymentTypes = PriceTypes.Cash)]
         Skinport = 10,
 
         [Display(Name = "LOOT.Farm")]
@@ -32,22 +32,23 @@ namespace SCMM.Steam.Data.Models.Enums
         [BuyFrom(Url = "https://loot.farm/", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)]
         LOOTFarm = 11,
 
-        [Display(Name = "Swap.gg - Trade")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#15C9AF")]
-        [BuyFrom(Url = "https://swap.gg/?r=iHUYPlp5ehjhrD5DXf0FF&game={0}", AffiliateCode = "iHUYPlp5ehjhrD5DXf0FF", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash)]
+        [Display(Name = "Swap.gg")]
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#15C9AF", AffiliateUrl = "https://swap.gg/?r=xu9CNezP5w")]
+        [BuyFrom(Url = "https://swap.gg/?r=xu9CNezP5w&game={0}", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash)]
         SwapGGTrade = 12,
 
+        // TODO: [Obsolete("Website discontinued from 29th February 2024")]
         [Display(Name = "Swap.gg - Market")]
         [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#15C9AF")]
-        [BuyFrom(Url = "https://market.swap.gg/{1}?r=iHUYPlp5ehjhrD5DXf0FF&search={3}", AffiliateCode = "iHUYPlp5ehjhrD5DXf0FF", AcceptedPaymentTypes = PriceTypes.Cash)]
+        [BuyFrom(Url = "https://market.swap.gg/{1}?search={3}", AcceptedPaymentTypes = PriceTypes.Cash)]
         SwapGGMarket = 13,
 
         // TODO: Use API key to bypass web scraping protection. Dev team haven't responded to my requests for API access yet
         [Obsolete("Tradeit.gg uses aggressive CloudFlare anti-scrapping policies, current web client gets blocked")]
         [Display(Name = "Tradeit.gg")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#27273F")]
-        [BuyFrom(Url = "https://tradeit.gg/{1}/trade?aff=scmm&search={3}", AffiliateCode = "scmm", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)]
-        [BuyFrom(Url = "https://tradeit.gg/{1}/store?aff=scmm&search={3}", AffiliateCode = "scmm", AcceptedPaymentTypes = PriceTypes.Cash | PriceTypes.Crypto, DiscountMultiplier = 0.25f /* 25% */)]
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#27273F", AffiliateUrl = "https://tradeit.gg/?aff=scmm")]
+        [BuyFrom(Url = "https://tradeit.gg/{1}/trade?aff=scmm&search={3}", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)]
+        [BuyFrom(Url = "https://tradeit.gg/{1}/store?aff=scmm&search={3}", AcceptedPaymentTypes = PriceTypes.Cash | PriceTypes.Crypto, DiscountMultiplier = 0.25f /* 25% */)]
         TradeitGG = 14,
 
         [Display(Name = "CS.Deals - Trade")]
@@ -68,20 +69,47 @@ namespace SCMM.Steam.Data.Models.Enums
         [BuyFrom(Url = "https://skinbaron.de/en/{1}?str={3}&sort=CF", AcceptedPaymentTypes = PriceTypes.Cash)]
         SkinBaron = 17,
 
+        [Display(Name = "RUST Skins")]
+        [Market(Constants.RustAppId, Color = "#EF7070")]
+        [BuyFrom(Url = "https://rustskins.com/market?search={3}&sort=p-ascending", AcceptedPaymentTypes = PriceTypes.Cash)]
+        RUSTSkins = 18,
+
         [Display(Name = "Rust.tm")]
         [Market(Constants.RustAppId, Color = "#4E2918")]
         [BuyFrom(Url = "https://rust.tm/?s=price&t=all&search={3}&sd=asc", AcceptedPaymentTypes = PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
         RustTM = 19,
 
+        //[Display(Name = "RUSTVendor")]
+        //[Market(Constants.RustAppId)]
+        //[BuyFrom(Url = "https://rustvendor.com/trade", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash)]
+        [Obsolete("Website is dead")]
+        RUSTVendor = 20,
+
+        // TODO: Implement web socket client support
+        //       wss://rustytrade.com/socket.io/?EIO=3&transport=websocket&sid=xxx
+        //          => 42["get bots inv"]
+        //          <= 42["bots inv",…]
+        //[Display(Name = "RustyTrade")]
+        //[Market(Constants.RustAppId)]
+        //[BuyFrom(Url = "https://rustytrade.com/", AcceptedPaymentTypes = PriceTypes.Trade)] // Unconfirmed
+        [Obsolete("Website is live, but seems to be inactive now")]
+        RustyTrade = 21,
+
         [Display(Name = "CS.TRADE")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#F3C207")]
-        [BuyFrom(Url = "https://cs.trade/ref/SCMM#trader", AffiliateCode = "SCMM", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#F3C207", AffiliateUrl = "https://cs.trade/ref/SCMM")]
+        [BuyFrom(Url = "https://cs.trade/ref/SCMM#trader", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
         CSTRADE = 22,
 
         [Display(Name = "iTrade.gg")]
-        [Market(Constants.RustAppId, Color = "#EA473B")]
-        [BuyFrom(Url = "https://itrade.gg/r/scmm?userInv={1}&botInv={1}", AffiliateCode = "scmm", AcceptedPaymentTypes = PriceTypes.Trade)] // Unconfirmed
+        [Market(Constants.RustAppId, Color = "#EA473B", AffiliateUrl = "https://itrade.gg/r/scmm")]
+        [BuyFrom(Url = "https://itrade.gg/r/scmm?userInv={1}&botInv={1}", AcceptedPaymentTypes = PriceTypes.Trade)] // Unconfirmed
         iTradegg = 23,
+
+        //[Display(Name = "Trade Skins Fast")]
+        //[Market(Constants.RustAppId, Constants.CSGOAppId)]
+        //[BuyFrom(Url = "https://tradeskinsfast.com/", AcceptedPaymentTypes = PriceTypes.Trade)]
+        [Obsolete("Website is dead")]
+        TradeSkinsFast = 24,
 
         [Display(Name = "SkinsMonkey")]
         [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#F5C71B")]
@@ -89,20 +117,20 @@ namespace SCMM.Steam.Data.Models.Enums
         SkinsMonkey = 25,
 
         [Display(Name = "Skin Swap")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#FF4B4B")]
-        [BuyFrom(Url = "https://skinswap.com/r/scmm", AffiliateCode = "scmm", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#FF4B4B", AffiliateUrl = "https://skinswap.com/r/scmm")]
+        [BuyFrom(Url = "https://skinswap.com/r/scmm", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
         SkinSwap = 26,
 
         // TODO: Restricted to 100 items per query, too slow for CSGO items
         [Display(Name = "DMarket")]
-        [Market(Constants.RustAppId, /*Constants.CSGOAppId,*/ Color = "#8dd294")]
-        [BuyFrom(Url = "https://dmarket.com/ingame-items/item-list/{1}-skins?ref=6tlej6xqvD&exchangeTab=exchange&title={3}", AffiliateCode = "6tlej6xqvD", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)]
+        [Market(Constants.RustAppId, /*Constants.CSGOAppId,*/ Color = "#8dd294", AffiliateUrl = "https://dmarket.com?ref=6tlej6xqvD")]
+        [BuyFrom(Url = "https://dmarket.com/ingame-items/item-list/{1}-skins?ref=6tlej6xqvD&exchangeTab=exchange&title={3}", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)]
         DMarket = 28,
 
         // TODO: Restricted to 100 items per query, too slow for CSGO items
         [Display(Name = "DMarket - Face2Face")]
         [Market(Constants.RustAppId, /*Constants.CSGOAppId,*/ Color = "#8dd294")]
-        [BuyFrom(Url = "https://dmarket.com/ingame-items/item-list/{1}-skins?ref=6tlej6xqvD&exchangeTab=f2fOffers&title={3}", AffiliateCode = "6tlej6xqvD", AcceptedPaymentTypes = PriceTypes.Cash | PriceTypes.Crypto)]
+        [BuyFrom(Url = "https://dmarket.com/ingame-items/item-list/{1}-skins?ref=6tlej6xqvD&exchangeTab=f2fOffers&title={3}", AcceptedPaymentTypes = PriceTypes.Cash | PriceTypes.Crypto)]
         DMarketF2F = 29,
 
         // TODO: Restricted to 80 items per query, too slow for CSGO items
@@ -115,7 +143,7 @@ namespace SCMM.Steam.Data.Models.Enums
          * https://docs.waxpeer.com/?method=prices-get
          * https://api.waxpeer.com/v1/prices?game=rust&minified=1
         [Display(Name = "Waxpeer")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#FFFFFF")]
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#FFFFFF", AffiliateUrl = "https://waxpeer.com/r/scmm")]
         [BuyFrom(Url = "https://waxpeer.com/rust/r/scmm?game={1}&sort=ASC&order=price&all=0&exact=0&search={3}", AffiliateCode = "scmm", AcceptedPaymentTypes = PriceTypes.Crypto)] // Unconfirmed
         Waxpeer = 31,
         */
@@ -124,8 +152,8 @@ namespace SCMM.Steam.Data.Models.Enums
          * https://doc.shadowpay.com/docs/shadowpay/96108be6ddc1e-get-items-on-sale
          * https://api.shadowpay.com/api/market/get_items?currency=USD&sort_column=price&sort_dir=asc&stack=false&offset=0&limit=50&sort=asc&game=rust
         [Display(Name = "ShadowPay")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#005BBB")]
-        [BuyFrom(Url = "https://shadowpay.com/en/{1}-items?utm_campaign=e6PlQUT3mUC06NL&price_from=0&price_to=500&currency=USD&search={3}&sort_column=price&sort_dir=asc", AffiliateCode = "e6PlQUT3mUC06NL", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Color = "#005BBB", AffiliateUrl = "https://shadowpay.com?utm_campaign=e6PlQUT3mUC06NL")]
+        [BuyFrom(Url = "https://shadowpay.com/en/{1}-items?utm_campaign=e6PlQUT3mUC06NL&price_from=0&price_to=500&currency=USD&search={3}&sort_column=price&sort_dir=asc", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash | PriceTypes.Crypto)] // Unconfirmed
         ShadowPay = 32,
         */
 
@@ -144,6 +172,7 @@ namespace SCMM.Steam.Data.Models.Enums
          BUY:  https://bandit.camp/
          BUY:  https://trade.skin/ (looks sus...)
          BUY:  https://rustplus.com/ (looks sus...)
+         BUY:  https://rapidskins.com/
          SELL: https://rustysell.com/
          SELL: https://skincashier.com/
          SELL: https://skins.cash/
@@ -151,36 +180,5 @@ namespace SCMM.Steam.Data.Models.Enums
 
         // https://pricempire.com/api
 
-        #region Deprecated Markets
-
-        //[Display(Name = "RUST Skins")]
-        //[Market(Constants.RustAppId, Color = "#EF7070")]
-        //[BuyFrom(Url = "https://rustskins.com/market?search={3}&sort=p-ascending", AcceptedPaymentTypes = PriceTypes.Cash)]
-        [Obsolete("Domain is dead. Unable to deposit cash. Social links are dead")]
-        RUSTSkins = 18,
-
-        //[Display(Name = "RUSTVendor")]
-        //[Market(Constants.RustAppId)]
-        //[BuyFrom(Url = "https://rustvendor.com/trade", AcceptedPaymentTypes = PriceTypes.Trade | PriceTypes.Cash)]
-        [Obsolete("Domain is dead. Unable to deposit cash. Social links are dead")]
-        RUSTVendor = 20,
-
-        // TODO: Implement web socket client support
-        //       wss://rustytrade.com/socket.io/?EIO=3&transport=websocket&sid=xxx
-        //          => 42["get bots inv"]
-        //          <= 42["bots inv",…]
-        //[Display(Name = "RustyTrade")]
-        //[Market(Constants.RustAppId)]
-        //[BuyFrom(Url = "https://rustytrade.com/", AcceptedPaymentTypes = PriceTypes.Trade)] // Unconfirmed
-        [Obsolete("Very inactive website, bot inventory doesn't load")]
-        RustyTrade = 21,
-
-        //[Display(Name = "Trade Skins Fast")]
-        //[Market(Constants.RustAppId, Constants.CSGOAppId)]
-        //[BuyFrom(Url = "https://tradeskinsfast.com/", AcceptedPaymentTypes = PriceTypes.Trade)]
-        [Obsolete("Domain is dead. Redirects to CS.Deals")]
-        TradeSkinsFast = 24,
-
-        #endregion
     }
 }

--- a/SCMM.Steam.Data.Models/Enums/MarketType.cs
+++ b/SCMM.Steam.Data.Models/Enums/MarketType.cs
@@ -69,6 +69,7 @@ namespace SCMM.Steam.Data.Models.Enums
         [BuyFrom(Url = "https://skinbaron.de/en/{1}?str={3}&sort=CF", AcceptedPaymentTypes = PriceTypes.Cash)]
         SkinBaron = 17,
 
+        [Obsolete("Needs to be revalidated again. Website is back online, but social links are dead")]
         [Display(Name = "RUST Skins")]
         [Market(Constants.RustAppId, Color = "#EF7070")]
         [BuyFrom(Url = "https://rustskins.com/market?search={3}&sort=p-ascending", AcceptedPaymentTypes = PriceTypes.Cash)]

--- a/SCMM.Steam.Data.Models/Enums/MarketType.cs
+++ b/SCMM.Steam.Data.Models/Enums/MarketType.cs
@@ -12,12 +12,12 @@ namespace SCMM.Steam.Data.Models.Enums
         Unknown = 0,
 
         [Display(Name = "Steam Store")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Constants.UnturnedAppId, Color = "#171A21")]
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Constants.UnturnedAppId, IsFirstParty = true, Color = "#171A21")]
         [BuyFrom(Url = "https://store.steampowered.com/itemstore/{0}/", AcceptedPaymentTypes = PriceTypes.Cash)]
         SteamStore = 1,
 
         [Display(Name = "Steam Community Market")]
-        [Market(Constants.RustAppId, Constants.CSGOAppId, Constants.UnturnedAppId, Color = "#171A21")]
+        [Market(Constants.RustAppId, Constants.CSGOAppId, Constants.UnturnedAppId, IsFirstParty = true, Color = "#171A21")]
         [BuyFrom(Url = "https://steamcommunity.com/market/listings/{0}/{3}", AcceptedPaymentTypes = PriceTypes.Cash)]
         [SellTo(Url = "https://steamcommunity.com/market/listings/{0}/{3}", AcceptedPaymentTypes = PriceTypes.Cash, FeeRate = 13.0f)]
         SteamCommunityMarket = 2,

--- a/SCMM.Steam.Data.Models/Extensions/MarketExtensions.cs
+++ b/SCMM.Steam.Data.Models/Extensions/MarketExtensions.cs
@@ -18,6 +18,13 @@ namespace SCMM.Steam.Data.Models.Extensions
             return market?.SupportedAppIds ?? new ulong[0];
         }
 
+        public static bool IsFirstParty(this MarketType marketType)
+        {
+            var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);
+            var market = marketTypeField?.GetCustomAttribute<MarketAttribute>();
+            return market?.IsFirstParty ?? false;
+        }
+
         public static string GetColor(this MarketType marketType)
         {
             var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);

--- a/SCMM.Steam.Data.Models/Extensions/MarketExtensions.cs
+++ b/SCMM.Steam.Data.Models/Extensions/MarketExtensions.cs
@@ -6,6 +6,21 @@ namespace SCMM.Steam.Data.Models.Extensions
 {
     public static class MarketExtensions
     {
+        public static string GetColor(this MarketType marketType)
+        {
+            return GetCustomAttribute<MarketAttribute>(marketType)?.Color;
+        }
+
+        public static string GetAffiliateUrl(this MarketType marketType)
+        {
+            return GetCustomAttribute<MarketAttribute>(marketType)?.AffiliateUrl;
+        }
+
+        public static bool IsFirstParty(this MarketType marketType)
+        {
+            return GetCustomAttribute<MarketAttribute>(marketType)?.IsFirstParty ?? false;
+        }
+
         public static bool IsAppSupported(this MarketType marketType, ulong appId)
         {
             return GetSupportedAppIds(marketType)?.Contains(appId) == true;
@@ -13,23 +28,7 @@ namespace SCMM.Steam.Data.Models.Extensions
 
         public static ulong[] GetSupportedAppIds(this MarketType marketType)
         {
-            var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);
-            var market = marketTypeField?.GetCustomAttribute<MarketAttribute>();
-            return market?.SupportedAppIds ?? new ulong[0];
-        }
-
-        public static bool IsFirstParty(this MarketType marketType)
-        {
-            var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);
-            var market = marketTypeField?.GetCustomAttribute<MarketAttribute>();
-            return market?.IsFirstParty ?? false;
-        }
-
-        public static string GetColor(this MarketType marketType)
-        {
-            var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);
-            var market = marketTypeField?.GetCustomAttribute<MarketAttribute>();
-            return market?.Color;
+            return GetCustomAttribute<MarketAttribute>(marketType)?.SupportedAppIds ?? new ulong[0];
         }
 
         public static IEnumerable<BuyFromAttribute> GetBuyFromOptions(this MarketType marketType)
@@ -42,6 +41,12 @@ namespace SCMM.Steam.Data.Models.Extensions
         {
             var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);
             return marketTypeField?.GetCustomAttributes<SellToAttribute>() ?? Enumerable.Empty<SellToAttribute>();
+        }
+
+        private static T GetCustomAttribute<T>(this MarketType marketType) where T : Attribute
+        {
+            var marketTypeField = typeof(MarketType).GetField(marketType.ToString(), BindingFlags.Public | BindingFlags.Static);
+            return marketTypeField?.GetCustomAttribute<T>();
         }
     }
 }

--- a/SCMM.Steam.Data.Models/MarketPrice.cs
+++ b/SCMM.Steam.Data.Models/MarketPrice.cs
@@ -1,5 +1,6 @@
 ﻿using SCMM.Shared.Data.Models;
 using SCMM.Steam.Data.Models.Enums;
+using SCMM.Steam.Data.Models.Extensions;
 
 namespace SCMM.Steam.Data.Models
 {
@@ -25,7 +26,7 @@ namespace SCMM.Steam.Data.Models
         /// <summary>
         /// If true, price is from a 1st party market, run by Steam/Value
         /// </summary>
-        public bool IsFirstPartyMarket => (MarketType == MarketType.SteamStore || MarketType == MarketType.SteamCommunityMarket);
+        public bool IsFirstPartyMarket => MarketType.IsFirstParty();
 
         public string Url { get; set; }
     }

--- a/SCMM.Steam.Data.Store/SteamProfile.cs
+++ b/SCMM.Steam.Data.Store/SteamProfile.cs
@@ -82,6 +82,14 @@ namespace SCMM.Steam.Data.Store
 
         [JsonIgnore]
         [NotMapped]
+        public MarketType[] MarketTypes
+        {
+            get { return Preferences.GetOrDefault(nameof(MarketTypes), String.Join(",", Enum.GetValues<MarketType>())).Split(",").Where(x => !String.IsNullOrEmpty(x)).Select(x => Enum.Parse<MarketType>(x)).ToArray(); }
+            set { Preferences[nameof(MarketTypes)] = String.Join(",", value); }
+        }
+
+        [JsonIgnore]
+        [NotMapped]
         public MarketValueType MarketValue
         {
             get { return Enum.Parse<MarketValueType>(Preferences.GetOrDefault(nameof(MarketValue), MarketValueType.SellOrderPrices.ToString()), true); }

--- a/SCMM.Steam.Functions/SCMM.Steam.Functions.csproj
+++ b/SCMM.Steam.Functions/SCMM.Steam.Functions.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="5.0.1" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.7.0" />
 		<PackageReference Include="CommandQuery.DependencyInjection" Version="1.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.14" />
+		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.15" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
 	</ItemGroup>
 	

--- a/SCMM.Web.Client/Pages/Inventory/InventoryItemsPanel.razor
+++ b/SCMM.Web.Client/Pages/Inventory/InventoryItemsPanel.razor
@@ -43,7 +43,7 @@ else
                 @if(SelectedInventoryItems != null && State.Is(SteamId))
                 {
                     <div class="@($"item-multi-select {((SelectedInventoryItems.ContainsKey(item.Id) && SelectedInventoryItems[item.Id] == true) ? "item-selected" : "item-hover-to-select")}")">
-                        <MudCheckBox T="bool" @bind-Checked="@SelectedInventoryItems[item.Id]" Color="Color.Primary" Class="ma-n1" Disabled="State.IsPrerendering" />
+                        <MudCheckBox T="bool" @bind-Value="@SelectedInventoryItems[item.Id]" Color="Color.Primary" Class="ma-n1" Disabled="State.IsPrerendering" />
                     </div>
                 }
             </div>

--- a/SCMM.Web.Client/Pages/Inventory/InventoryPage.razor
+++ b/SCMM.Web.Client/Pages/Inventory/InventoryPage.razor
@@ -54,7 +54,7 @@
             }
             else
             {
-                <MudTabs Elevation="0" ActivePanelIndex="PanelIndex" ActivePanelIndexChanged="OnSelectedPanelChanged" Class="mud-tabs-transparent">
+                <MudTabs @bind-ActivePanelIndex="PanelIndex" Elevation="0" KeepPanelsAlive="false" Class="mud-tabs-transparent">
                     <ChildContent>
                         <MudTabPanel Icon="fas fa-fw fa-th mr-2" Text="Inventory" Disabled="State.IsPrerendering">
                             <MudPaper Outlined="true">
@@ -200,13 +200,15 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        switch (Panel)
+        if (!String.IsNullOrEmpty(Panel))
         {
-            case "items": PanelIndex = 0; break;
-            case "collections": PanelIndex = 1; break;
-            case "market": PanelIndex = 2; break;
-            case "investment": PanelIndex = 3; break;
-            case "statistics": PanelIndex = 4; break;
+            switch (Panel)
+            {
+                case "items": PanelIndex = 0; break;
+                case "collections": PanelIndex = 1; break;
+                case "market": PanelIndex = 2; break;
+                case "investment": PanelIndex = 3; break;
+            }
         }
 
         // If we have navigated to a different profile, reload the new profile
@@ -229,24 +231,6 @@
         SortBy = sortBy;
         SortDirection = sortDirection.ToString();
         StateHasChanged();
-    }
-
-    private void OnSelectedPanelChanged(int index)
-    {
-        var filter = !String.IsNullOrEmpty(Filter) ? $"&filter={Uri.EscapeDataString(Filter)}" : String.Empty;
-
-        PanelIndex = index;
-        if (!State.IsPrerendering)
-        {
-            switch (index)
-            {
-                case 0: NavigationManager.NavigateTo($"/inventory/{Uri.EscapeDataString(SteamId)}?panel=items{filter}"); break;
-                case 1: NavigationManager.NavigateTo($"/inventory/{Uri.EscapeDataString(SteamId)}?panel=collections{filter}"); break;
-                case 2: NavigationManager.NavigateTo($"/inventory/{Uri.EscapeDataString(SteamId)}?panel=market{filter}"); break;
-                case 3: NavigationManager.NavigateTo($"/inventory/{Uri.EscapeDataString(SteamId)}?panel=investment{filter}"); break;
-                case 4: NavigationManager.NavigateTo($"/inventory/{Uri.EscapeDataString(SteamId)}?panel=statistics{filter}"); break;
-            }
-        }
     }
 
     private void ViewProfileOnSteam()

--- a/SCMM.Web.Client/Pages/Items/ItemsPage.razor
+++ b/SCMM.Web.Client/Pages/Items/ItemsPage.razor
@@ -100,37 +100,37 @@
                             <div Class="d-flex flex-row align-center justify-center flex-wrap pa-2 px-4">
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureGlowing))
                                 {
-                                    <MudSwitch T="bool" Checked="@Glow" CheckedChanged="@((x) => { Glow = x; _ = RefreshItems(); })" Label="Glow" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                                    <MudSwitch T="bool" Checked="@Glowsight" CheckedChanged="@((x) => { Glowsight = x; _ = RefreshItems(); })" Label="Glowsight" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@Glow" ValueChanged="@((x) => { Glow = x; _ = RefreshItems(); })" Label="Glow" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@Glowsight" ValueChanged="@((x) => { Glowsight = x; _ = RefreshItems(); })" Label="Glowsight" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureCutout))
                                 {
-                                    <MudSwitch T="bool" Checked="@Cutout" CheckedChanged="@((x) => { Cutout = x; _ = RefreshItems(); })" Label="Cutout" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@Cutout" ValueChanged="@((x) => { Cutout = x; _ = RefreshItems(); })" Label="Cutout" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureCrafting))
                                 {
-                                    <MudSwitch T="bool" Checked="@Craftable" CheckedChanged="@((x) => { Craftable = x; _ = RefreshItems(); })" Label="Craftable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@Craftable" ValueChanged="@((x) => { Craftable = x; _ = RefreshItems(); })" Label="Craftable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeaturePublisherDrops))
                                 {
-                                    <MudSwitch T="bool" Checked="@PublisherDrop" CheckedChanged="@((x) => { PublisherDrop = x; _ = RefreshItems(); })" Label="@($"{State.App?.PublisherName ?? "Publisher"} Drop")" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@PublisherDrop" ValueChanged="@((x) => { PublisherDrop = x; _ = RefreshItems(); })" Label="@($"{State.App?.PublisherName ?? "Publisher"} Drop")" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureTwitchDrops))
                                 {
-                                    <MudSwitch T="bool" Checked="@TwitchDrop" CheckedChanged="@((x) => { TwitchDrop = x; _ = RefreshItems(); })" Label="Twitch Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@TwitchDrop" ValueChanged="@((x) => { TwitchDrop = x; _ = RefreshItems(); })" Label="Twitch Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureLootCrates))
                                 {
-                                    <MudSwitch T="bool" Checked="@LootCrateDrop" CheckedChanged="@((x) => { LootCrateDrop = x; _ = RefreshItems(); })" Label="Loot Crate Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@LootCrateDrop" ValueChanged="@((x) => { LootCrateDrop = x; _ = RefreshItems(); })" Label="Loot Crate Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
-                                <MudSwitch T="bool" Checked="@Tradable" CheckedChanged="@((x) => { Tradable = x; _ = RefreshItems(); })" Label="Tradable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                                <MudSwitch T="bool" Checked="@Marketable" CheckedChanged="@((x) => { Marketable = x; _ = RefreshItems(); })" Label="Marketable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                <MudSwitch T="bool" Value="@Tradable" ValueChanged="@((x) => { Tradable = x; _ = RefreshItems(); })" Label="Tradable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                <MudSwitch T="bool" Value="@Marketable" ValueChanged="@((x) => { Marketable = x; _ = RefreshItems(); })" Label="Marketable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemStoreRotating))
                                 {
-                                    <MudSwitch T="bool" Checked="@Returning" CheckedChanged="@((x) => { Returning = x; _ = RefreshItems(); })" Label="Returning" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                    <MudSwitch T="bool" Value="@Returning" ValueChanged="@((x) => { Returning = x; _ = RefreshItems(); })" Label="Returning" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                                 }
-                                <MudSwitch T="bool" Checked="@Banned" CheckedChanged="@((x) => { Banned = x; _ = RefreshItems(); })" Label="Banned" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                                <MudSwitch T="bool" Checked="@Manipulated" CheckedChanged="@((x) => { Manipulated = x; _ = RefreshItems(); })" Label="Manipulated" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                <MudSwitch T="bool" Value="@Banned" ValueChanged="@((x) => { Banned = x; _ = RefreshItems(); })" Label="Banned" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                                <MudSwitch T="bool" Value="@Manipulated" ValueChanged="@((x) => { Manipulated = x; _ = RefreshItems(); })" Label="Manipulated" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                             </div>
                         </ChildContent>
                     </MudExpansionPanel>
@@ -140,38 +140,38 @@
                 <MudPaper Outlined="true" Class="d-flex flex-row align-center justify-center flex-wrap pa-2 px-4">
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureGlowing))
                     {
-                        <MudSwitch T="bool" Checked="@Glow" CheckedChanged="@((x) => { Glow = x; _ = RefreshItems(); })" Label="Glow" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                        <MudSwitch T="bool" Checked="@Glowsight" CheckedChanged="@((x) => { Glowsight = x; _ = RefreshItems(); })" Label="Glowsight" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@Glow" ValueChanged="@((x) => { Glow = x; _ = RefreshItems(); })" Label="Glow" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@Glowsight" ValueChanged="@((x) => { Glowsight = x; _ = RefreshItems(); })" Label="Glowsight" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureCutout))
                     {
-                        <MudSwitch T="bool" Checked="@Cutout" CheckedChanged="@((x) => { Cutout = x; _ = RefreshItems(); })" Label="Cutout" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@Cutout" ValueChanged="@((x) => { Cutout = x; _ = RefreshItems(); })" Label="Cutout" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureCrafting))
                     {
-                        <MudSwitch T="bool" Checked="@Craftable" CheckedChanged="@((x) => { Craftable = x; _ = RefreshItems(); })" Label="Craftable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@Craftable" ValueChanged="@((x) => { Craftable = x; _ = RefreshItems(); })" Label="Craftable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeaturePublisherDrops))
                     {
-                        <MudSwitch T="bool" Checked="@PublisherDrop" CheckedChanged="@((x) => { PublisherDrop = x; _ = RefreshItems(); })" Label="@($"{State.App?.PublisherName ?? "Publisher"} Drop")" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@PublisherDrop" ValueChanged="@((x) => { PublisherDrop = x; _ = RefreshItems(); })" Label="@($"{State.App?.PublisherName ?? "Publisher"} Drop")" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureTwitchDrops))
                     {
-                        <MudSwitch T="bool" Checked="@TwitchDrop" CheckedChanged="@((x) => { TwitchDrop = x; _ = RefreshItems(); })" Label="Twitch Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@TwitchDrop" ValueChanged="@((x) => { TwitchDrop = x; _ = RefreshItems(); })" Label="Twitch Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemFeatureLootCrates))
                     {
-                        <MudSwitch T="bool" Checked="@LootCrateDrop" CheckedChanged="@((x) => { LootCrateDrop = x; _ = RefreshItems(); })" Label="Loot Crate Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@LootCrateDrop" ValueChanged="@((x) => { LootCrateDrop = x; _ = RefreshItems(); })" Label="Loot Crate Drop" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
-                    <MudSwitch T="bool" Checked="@Commodity" CheckedChanged="@((x) => { Commodity = x; _ = RefreshItems(); })" Label="Commodity " Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                    <MudSwitch T="bool" Checked="@Tradable" CheckedChanged="@((x) => { Tradable = x; _ = RefreshItems(); })" Label="Tradable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                    <MudSwitch T="bool" Checked="@Marketable" CheckedChanged="@((x) => { Marketable = x; _ = RefreshItems(); })" Label="Marketable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                    <MudSwitch T="bool" Value="@Commodity" ValueChanged="@((x) => { Commodity = x; _ = RefreshItems(); })" Label="Commodity " Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                    <MudSwitch T="bool" Value="@Tradable" ValueChanged="@((x) => { Tradable = x; _ = RefreshItems(); })" Label="Tradable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                    <MudSwitch T="bool" Value="@Marketable" ValueChanged="@((x) => { Marketable = x; _ = RefreshItems(); })" Label="Marketable" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     @if (State.App.Features.HasFlag(SteamAppFeatureTypes.ItemStoreRotating))
                     {
-                        <MudSwitch T="bool" Checked="@Returning" CheckedChanged="@((x) => { Returning = x; _ = RefreshItems(); })" Label="Returning" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                        <MudSwitch T="bool" Value="@Returning" ValueChanged="@((x) => { Returning = x; _ = RefreshItems(); })" Label="Returning" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                     }
-                    <MudSwitch T="bool" Checked="@Banned" CheckedChanged="@((x) => { Banned = x; _ = RefreshItems(); })" Label="Banned" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
-                    <MudSwitch T="bool" Checked="@Manipulated" CheckedChanged="@((x) => { Manipulated = x; _ = RefreshItems(); })" Label="Manipulated" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                    <MudSwitch T="bool" Value="@Banned" ValueChanged="@((x) => { Banned = x; _ = RefreshItems(); })" Label="Banned" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
+                    <MudSwitch T="bool" Value="@Manipulated" ValueChanged="@((x) => { Manipulated = x; _ = RefreshItems(); })" Label="Manipulated" Color="Color.Primary" Class="mr-10" Disabled="State.IsPrerendering" />
                 </MudPaper>
             </MudHidden>
         </MudItem>

--- a/SCMM.Web.Client/Pages/Market/MarketDealsPage.razor
+++ b/SCMM.Web.Client/Pages/Market/MarketDealsPage.razor
@@ -42,7 +42,7 @@
                                         <MudSelectItem Value="@((MarketType?)null)">
                                             <span>Cheapest offer from <strong>all markets</strong></span>
                                         </MudSelectItem>
-                                        @foreach (var marketType in Enum.GetValues<MarketType>().Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)).Where(x => x > SCMM.Steam.Data.Models.Enums.MarketType.SteamCommunityMarket))
+                                        @foreach (var marketType in State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId) && !x.IsFirstParty()))
                                         {
                                             <MudSelectItem Value="@((MarketType?)marketType)" Class="d-flex justify-start align-center">
                                                 <span>Cheapest </span>
@@ -154,7 +154,7 @@
                                         <MudSelectItem Value="@((MarketType?)null)">
                                             <span>Buy it from the <strong>cheapest market</strong></span>
                                         </MudSelectItem>
-                                        @foreach (var marketType in Enum.GetValues<MarketType>().Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)).Where(x => x > SCMM.Steam.Data.Models.Enums.MarketType.SteamCommunityMarket))
+                                        @foreach (var marketType in State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()))
                                         {
                                             <MudSelectItem Value="@((MarketType?)marketType)" Class="d-flex justify-start align-center">
                                                 <span>Buy it from </span>

--- a/SCMM.Web.Client/Pages/Market/MarketDealsPage.razor
+++ b/SCMM.Web.Client/Pages/Market/MarketDealsPage.razor
@@ -49,7 +49,7 @@
                                                 <MudSelectItem Value="@((MarketType?)marketType)">
                                                     <div class="d-flex justify-start align-center">
                                                         <span>Cheapest </span>
-                                                        <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mr-2" style="width:1.5em; height:1.5em" />
+                                                        <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mx-2" style="width:1.5em; height:1.5em" />
                                                         <span><strong>@marketType.GetDisplayName()</strong> offer</span>
                                                     </div>
                                                 </MudSelectItem>
@@ -170,7 +170,7 @@
                                                 <MudSelectItem Value="@((MarketType?)marketType)">
                                                     <div class="d-flex justify-start align-center">
                                                     <span>Buy it from </span>
-                                                        <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mr-2" style="width:1.5em; height:1.5em" />
+                                                        <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mx-2" style="width:1.5em; height:1.5em" />
                                                     <span><strong>@marketType.GetDisplayName()</strong></span>
                                                     </div>
                                                 </MudSelectItem>

--- a/SCMM.Web.Client/Pages/Market/MarketDealsPage.razor
+++ b/SCMM.Web.Client/Pages/Market/MarketDealsPage.razor
@@ -16,249 +16,267 @@
 
 <PageContainer Title="@($"{State?.App?.Name} Market Deals")">
     <MudAlert Icon="fa fa-fw fa-exclamation-triangle" Severity="Severity.Warning" Variant="MudBlazor.Variant.Text" Class="mud-alert-outlined-warning">
-        <span>Always double check prices yourself before buying or selling. Prices shown here update once every hour and some deals may no longer be available.</span>
+        <span>Always double check prices manually before buying or selling from a third-party market. Prices shown here update once every hour and may no longer be available.</span>
     </MudAlert>
-    <MudTabs Elevation="0" ActivePanelIndex="TabIndex" ActivePanelIndexChanged="OnSelectedTabChanged" Class="mud-tabs-transparent">
+    <MudTabs Elevation="0" ActivePanelIndex="TabIndex" ActivePanelIndexChanged="OnSelectedTabChanged" KeepPanelsAlive="false" Class="mud-tabs-transparent">
         <ChildContent>
 
             <MudTabPanel Icon="fas fa-fw fa-search-dollar mr-2" Text="Cheapest Offers" Disabled="State.IsPrerendering">
                 <AnalyticsPanel>
-                    <MudText Typo="Typo.body2" Color="Color.Secondary" GutterBottom="true">
-                        <span>Looking to buy a particular item?</span><br/>
-                        <span>Find the cheapest offer across all markets here.</span>
-                    </MudText>
-                    <MudSimpleTable Dense="true" Hover="true" FixedHeader="true" Class="mx-n4 mb-n4" Style="height:70vh;">
-                        <thead>
-                            <tr>
-                                <th class="py-0 my-0">
-                                    <MudTextField T="string" Value="Filter" ValueChanged="async (x) => { Filter = x; await VirtualiseMarketCheapestListings.RefreshDataAsync(); StateHasChanged(); }" DebounceInterval="500" 
-                                                  Placeholder="Search items..." FullWidth="true" Class="mud-input-full-height ma-0" Adornment="Adornment.Start" AdornmentIcon="fas fa-fw fa-filter mr-2" IconSize="MudBlazor.Size.Small" Disabled="State.IsPrerendering" />
-                                </th>
-                                <th>
-                                    <MudSelect T="MarketType?" Value="@MarketType" ValueChanged="async (x) => { MarketType = x; await VirtualiseMarketCheapestListings.RefreshDataAsync(); StateHasChanged(); }" 
-                                               ToStringFunc="@(x => $"Cheapest {(x != null ? $"{x.GetDisplayName()} offer" : "offer from all markets")}")"
-                                               Margin="MudBlazor.Margin.None" Dense="true" FullWidth="true" Class="mud-input-full-height mud-input-transparent ma-0" Disabled="State.IsPrerendering">
+                    @if (State.Profile.MarketTypes.Any())
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" GutterBottom="true">
+                            <span>Looking to buy a particular item?</span><br/>
+                            <span>Find the cheapest offer across all markets here.</span>
+                        </MudText>
+                        <MudSimpleTable Dense="true" Hover="true" FixedHeader="true" Class="mx-n4 mb-n4" Style="height:70vh;">
+                            <thead>
+                                <tr>
+                                    <th class="py-0 my-0">
+                                        <MudTextField T="string" Value="Filter" ValueChanged="async (x) => { Filter = x; await VirtualiseMarketCheapestListings.RefreshDataAsync(); StateHasChanged(); }" DebounceInterval="500" 
+                                                      Placeholder="Search items..." FullWidth="true" Class="mud-input-full-height ma-0" Adornment="Adornment.Start" AdornmentIcon="fas fa-fw fa-filter mr-2" IconSize="MudBlazor.Size.Small" Disabled="State.IsPrerendering" />
+                                    </th>
+                                    <th>
+                                        <MudSelect T="MarketType?" Value="@MarketType" ValueChanged="async (x) => { MarketType = x; await VirtualiseMarketCheapestListings.RefreshDataAsync(); StateHasChanged(); }" 
+                                                   ToStringFunc="@(x => $"Cheapest {(x != null ? $"{x.GetDisplayName()} offer" : "offer from all markets")}")"
+                                                   Margin="MudBlazor.Margin.None" Dense="true" FullWidth="true" Class="mud-input-full-height mud-input-transparent ma-0" Disabled="State.IsPrerendering">
                                         
-                                        <MudSelectItem Value="@((MarketType?)null)">
-                                            <span>Cheapest offer from <strong>all markets</strong></span>
-                                        </MudSelectItem>
-                                        @foreach (var marketType in State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId) && !x.IsFirstParty()))
-                                        {
-                                            <MudSelectItem Value="@((MarketType?)marketType)" Class="d-flex justify-start align-center">
-                                                <span>Cheapest </span>
-                                                <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mx-1" style="width:1em; height:1em" />
-                                                <span><strong>@marketType.GetDisplayName()</strong> offer</span>
+                                            <MudSelectItem Value="@((MarketType?)null)">
+                                                <span>Cheapest offer from <strong>all markets</strong></span>
                                             </MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </th>
-                                <th>Steam Community Market</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <Virtualize @ref="VirtualiseMarketCheapestListings" ItemsProvider="LoadMarketCheapestListings" Context="item" SpacerElement="tr">
-                                <ItemContent>
-                                    <tr>
-                                        <td>
-                                            <div class="d-flex flex-row justify-start align-center clickable hover-zoom" @onclick="@(() => ShowItemDetailsDialog(item.Name, item.Id.ToString()))">
-                                                <img src="@item.IconUrl" class="mr-1" style="width:32px; height:32px;" />
-                                                <MudText Typo="Typo.body2">@item.Name</MudText>
-                                                @if (item.IsBeingManipulated)
-                                                {
-                                                    <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Warning" Size="MudBlazor.Size.Small" Icon="fas fa-fw fa-exclamation-triangle" Text="Price Manipulation" title="@($"It is suspected that this items price is being manipulated on the market because {item.ManipulationReason.FirstCharToLower()}")" Class="ml-2" />
-                                                }
-                                            </div>
-                                        </td>
-                                        <td>
-                                            <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
-                                                <MudButton Variant="Variant.Filled" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="Size.Small" OnClick="@((_) => BuyItem(item.BuyUrl))" Disabled="State.IsPrerendering">Buy</MudButton>
-                                                <img src="@($"/images/app/{State.App.Id}/markets/{item.BuyFrom.ToString().ToLower()}.png")" alt="@item.BuyFrom.GetDisplayName()" title="@item.BuyFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
-                                                <span>@State.Currency.ToPriceString(item.BuyTotal)</span>
-                                                @if (State.Profile.ItemIncludeMarketFees && item.BuyFee != 0)
-                                                {
+                                            @foreach (var marketType in State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId) && !x.IsFirstParty()))
+                                            {
+                                                <MudSelectItem Value="@((MarketType?)marketType)">
+                                                    <div class="d-flex justify-start align-center">
+                                                        <span>Cheapest </span>
+                                                        <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mr-2" style="width:1.5em; height:1.5em" />
+                                                        <span><strong>@marketType.GetDisplayName()</strong> offer</span>
+                                                    </div>
+                                                </MudSelectItem>
+                                            }
+                                        </MudSelect>
+                                    </th>
+                                    <th>Steam Community Market</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <Virtualize @ref="VirtualiseMarketCheapestListings" ItemsProvider="LoadMarketCheapestListings" Context="item" SpacerElement="tr">
+                                    <ItemContent>
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex flex-row justify-start align-center clickable hover-zoom" @onclick="@(() => ShowItemDetailsDialog(item.Name, item.Id.ToString()))">
+                                                    <img src="@item.IconUrl" class="mr-1" style="width:32px; height:32px;" />
+                                                    <MudText Typo="Typo.body2">@item.Name</MudText>
+                                                    @if (item.IsBeingManipulated)
+                                                    {
+                                                        <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Warning" Size="MudBlazor.Size.Small" Icon="fas fa-fw fa-exclamation-triangle" Text="Price Manipulation" title="@($"It is suspected that this items price is being manipulated on the market because {item.ManipulationReason.FirstCharToLower()}")" Class="ml-2" />
+                                                    }
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
+                                                    <MudButton Variant="Variant.Filled" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="Size.Small" OnClick="@((_) => BuyItem(item.BuyUrl))" Disabled="State.IsPrerendering">Buy</MudButton>
+                                                    <img src="@($"/images/app/{State.App.Id}/markets/{item.BuyFrom.ToString().ToLower()}.png")" alt="@item.BuyFrom.GetDisplayName()" title="@item.BuyFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
+                                                    <span>@State.Currency.ToPriceString(item.BuyTotal)</span>
+                                                    @if (State.Profile.ItemIncludeMarketFees && item.BuyFee != 0)
+                                                    {
+                                                        <MudTooltip>
+                                                            <TooltipContent>
+                                                                @if (item.BuyFee > 0)
+                                                                {
+                                                                    <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimated fees charged by @item.BuyFrom.GetDisplayName()</span>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimate discounts gained by purchasing new @item.BuyFrom.GetDisplayName() balance</span>
+                                                                }
+                                                            </TooltipContent>
+                                                            <ChildContent>
+                                                                <i class="fa fa-fw fa-comment-dollar"></i>
+                                                            </ChildContent>
+                                                        </MudTooltip>
+                                                    }
                                                     <MudTooltip>
                                                         <TooltipContent>
-                                                            @if (item.BuyFee > 0)
-                                                            {
-                                                                <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimated fees charged by @item.BuyFrom.GetDisplayName()</span>
-                                                            }
-                                                            else
-                                                            {
-                                                                <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimate discounts gained by purchasing new @item.BuyFrom.GetDisplayName() balance</span>
-                                                            }
+                                                            <span>Save @State.Currency.ToPriceString(item.DiscountAmount)</span>
                                                         </TooltipContent>
                                                         <ChildContent>
-                                                            <i class="fa fa-fw fa-comment-dollar"></i>
+                                                            <MudChip Variant="Variant.Text" Color="@(item.IsBeingManipulated ? Color.Warning : ((item.DiscountAmount > 0) ? Color.Success : Color.Secondary))" Size="@Size.Small" Text="@($"-{item.DiscountAmount.ToPercentageString(item.ReferemcePrice) ?? "0%"}")" />
                                                         </ChildContent>
                                                     </MudTooltip>
-                                                }
-                                                <MudTooltip>
-                                                    <TooltipContent>
-                                                        <span>Save @State.Currency.ToPriceString(item.DiscountAmount)</span>
-                                                    </TooltipContent>
-                                                    <ChildContent>
-                                                        <MudChip Variant="Variant.Text" Color="@(item.IsBeingManipulated ? Color.Warning : ((item.DiscountAmount > 0) ? Color.Success : Color.Secondary))" Size="@Size.Small" Text="@($"-{item.DiscountAmount.ToPercentageString(item.ReferemcePrice) ?? "0%"}")" />
-                                                    </ChildContent>
-                                                </MudTooltip>
-                                                @if (GetTimeSinceLastMarketPriceUpdate(item.BuyFrom) != null)
-                                                {
-                                                    <small class="mud-secondary-text"> @GetTimeSinceLastMarketPriceUpdate(item.BuyFrom).Value.ToDurationString(maxGranularity: 2, prefix: "price checked", suffix: "ago") </small>
-                                                }
-                                            </MudText>
-                                        </td>
-                                        <td>
-                                            <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
-                                                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Size="Size.Small" OnClick="@((_) => ViewMarketItem(item.AppId, item.Name))" Disabled="State.IsPrerendering">Compare</MudButton>
-                                                <img src="@($"/images/app/{State.App.Id}/markets/{item.ReferenceFrom.ToString().ToLower()}.png")" alt="@item.ReferenceFrom.GetDisplayName()" title="@item.ReferenceFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
-                                                <span>@State.Currency.ToPriceString(item.ReferemcePrice)</span>
-                                            </MudText>
-                                        </td>
-                                    </tr>
-                                </ItemContent>
-                                <Placeholder>
-                                    <tr>
-                                        <td>
-                                            <div class="d-flex flex-row justify-start align-center">
-                                                <MudProgressCircular Indeterminate="true" Class="mr-1" Style="width:32px; height:32px;" />
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Loading...</MudText>
-                                            </div>
-                                        </td>
-                                        <td>—</td>
-                                        <td>—</td>
-                                    </tr>
-                                </Placeholder>
-                            </Virtualize>
-                        </tbody>
-                    </MudSimpleTable>
+                                                    @if (GetTimeSinceLastMarketPriceUpdate(item.BuyFrom) != null)
+                                                    {
+                                                        <small class="mud-secondary-text"> @GetTimeSinceLastMarketPriceUpdate(item.BuyFrom).Value.ToDurationString(maxGranularity: 2, prefix: "price checked", suffix: "ago") </small>
+                                                    }
+                                                </MudText>
+                                            </td>
+                                            <td>
+                                                <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
+                                                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Size="Size.Small" OnClick="@((_) => ViewMarketItem(item.AppId, item.Name))" Disabled="State.IsPrerendering">Compare</MudButton>
+                                                    <img src="@($"/images/app/{State.App.Id}/markets/{item.ReferenceFrom.ToString().ToLower()}.png")" alt="@item.ReferenceFrom.GetDisplayName()" title="@item.ReferenceFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
+                                                    <span>@State.Currency.ToPriceString(item.ReferemcePrice)</span>
+                                                </MudText>
+                                            </td>
+                                        </tr>
+                                    </ItemContent>
+                                    <Placeholder>
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex flex-row justify-start align-center">
+                                                    <MudProgressCircular Indeterminate="true" Class="mr-1" Style="width:32px; height:32px;" />
+                                                    <MudText Typo="Typo.body2" Color="Color.Secondary">Loading...</MudText>
+                                                </div>
+                                            </td>
+                                            <td>—</td>
+                                            <td>—</td>
+                                        </tr>
+                                    </Placeholder>
+                                </Virtualize>
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                    else
+                    {
+                        <Alert Severity="Severity.Normal" Icon="fas fa-fw fa-shop mr-2" Title="No third-party markets enabled" SubTitle="To use this feature, enable at least one third-party market in your profile preferences." />
+                    }
                 </AnalyticsPanel>
             </MudTabPanel>
 
             <MudTabPanel Icon="fas fa-fw fa-exchange-alt mr-2" Text="Profitable Flips" Disabled="State.IsPrerendering">
                 <AnalyticsPanel>
-                    <MudText Typo="Typo.body2" Color="Color.Secondary" GutterBottom="true">
-                        <span>Looking to top up your Steam wallet balance?</span><br/>
-                        <span>Buy these undervalued items from third party markets and flip them on the Steam Community Market for profit. Quick profit can be made by flipping instantly to the highest buy order. Maximum profit can be made by listing a sell order and waiting for somebody to buy it.</span>
-                    </MudText>
-                    <MudSimpleTable Dense="true" Hover="true" FixedHeader="true" Class="mx-n4 mb-n4" Style="height:70vh;">
-                        <thead>
-                            <tr>
-                                <th class="py-0 my-0">
-                                    <MudTextField T="string" Value="Filter" ValueChanged="async (x) => { Filter = x; await VirtualiseMarketFlips.RefreshDataAsync(); StateHasChanged(); }" DebounceInterval="500" 
-                                                  Placeholder="Search items..." FullWidth="true" Class="mud-input-full-height ma-0" Adornment="Adornment.Start" AdornmentIcon="fas fa-fw fa-filter mr-2" IconSize="MudBlazor.Size.Small" Disabled="State.IsPrerendering" />
-                                </th>
-                                <th>
-                                    <MudSelect T="MarketType?" Value="@MarketType" ValueChanged="async (x) => { MarketType = x; await VirtualiseMarketFlips.RefreshDataAsync(); StateHasChanged(); }" 
-                                               ToStringFunc="@(x => $"Buy it {(x != null ? $"from {x.GetDisplayName()}" : "from the cheapest market")}")"
-                                               Margin="MudBlazor.Margin.None" Dense="true" FullWidth="true" Class="mud-input-full-height mud-input-transparent ma-0" Disabled="State.IsPrerendering">
+                    @if (State.Profile.MarketTypes.Any())
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" GutterBottom="true">
+                            <span>Looking to top up your Steam wallet balance?</span><br/>
+                            <span>Buy these undervalued items from third party markets and flip them on the Steam Community Market for profit. Quick profit can be made by flipping instantly to the highest buy order. Maximum profit can be made by listing a sell order and waiting for somebody to buy it.</span>
+                        </MudText>
+                        <MudSimpleTable Dense="true" Hover="true" FixedHeader="true" Class="mx-n4 mb-n4" Style="height:70vh;">
+                            <thead>
+                                <tr>
+                                    <th class="py-0 my-0">
+                                        <MudTextField T="string" Value="Filter" ValueChanged="async (x) => { Filter = x; await VirtualiseMarketFlips.RefreshDataAsync(); StateHasChanged(); }" DebounceInterval="500" 
+                                                      Placeholder="Search items..." FullWidth="true" Class="mud-input-full-height ma-0" Adornment="Adornment.Start" AdornmentIcon="fas fa-fw fa-filter mr-2" IconSize="MudBlazor.Size.Small" Disabled="State.IsPrerendering" />
+                                    </th>
+                                    <th>
+                                        <MudSelect T="MarketType?" Value="@MarketType" ValueChanged="async (x) => { MarketType = x; await VirtualiseMarketFlips.RefreshDataAsync(); StateHasChanged(); }" 
+                                                   ToStringFunc="@(x => $"Buy it {(x != null ? $"from {x.GetDisplayName()}" : "from the cheapest market")}")"
+                                                   Margin="MudBlazor.Margin.None" Dense="true" FullWidth="true" Class="mud-input-full-height mud-input-transparent ma-0" Disabled="State.IsPrerendering">
                                         
-                                        <MudSelectItem Value="@((MarketType?)null)">
-                                            <span>Buy it from the <strong>cheapest market</strong></span>
-                                        </MudSelectItem>
-                                        @foreach (var marketType in State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()))
-                                        {
-                                            <MudSelectItem Value="@((MarketType?)marketType)" Class="d-flex justify-start align-center">
-                                                <span>Buy it from </span>
-                                                <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mx-1" style="width:1em; height:1em" />
-                                                <span><strong>@marketType.GetDisplayName()</strong></span>
+                                            <MudSelectItem Value="@((MarketType?)null)">
+                                                <span>Buy it from the <strong>cheapest market</strong></span>
                                             </MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                </th>
-                                <th class="pa-0">
-                                    <i class="fa fa-fw fa-arrow-right"></i>
-                                </th>
-                                <th>
-                                    <MudSelect T="bool?" Value="@SellNow" ValueChanged="OnSellNowChanged" Margin="Margin.None" Dense="true" FullWidth="true" Class="mud-input-full-height mud-input-transparent ma-0" Disabled="State.IsPrerendering">
-                                        <MudSelectItem Value="@((bool?)true)">
-                                            <span><strong>Sell it now</strong> for quick profit</span>
-                                        </MudSelectItem>
-                                        <MudSelectItem Value="@((bool?)false)">
-                                            <span><strong>List it now</strong> and <strong>sell later</strong> for maximum profit</span>
-                                        </MudSelectItem>
-                                    </MudSelect>
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <Virtualize @ref="VirtualiseMarketFlips" ItemsProvider="LoadMarketFlips" Context="item" SpacerElement="tr">
-                                <ItemContent>
-                                    <tr>
-                                        <td>
-                                            <div class="d-flex flex-row justify-start align-center clickable hover-zoom" @onclick="@(() => ShowItemDetailsDialog(item.Name, item.Id.ToString()))">
-                                                <img src="@item.IconUrl" class="mr-2" style="width:32px; height:32px;" />
-                                                <MudText Typo="Typo.body2">@item.Name</MudText>
-                                                @if (item.IsBeingManipulated)
-                                                {
-                                                    <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Warning" Size="MudBlazor.Size.Small" Icon="fas fa-fw fa-exclamation-triangle" Text="Price Manipulation" title="@($"It is suspected that this items price is being manipulated on the market because {item.ManipulationReason.FirstCharToLower()}")" Class="ml-2" />
-                                                }
-                                            </div>
-                                        </td>
-                                        <td>
-                                            <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
-                                                <MudButton Variant="Variant.Filled" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="Size.Small" OnClick="@((_) => BuyItem(item.BuyUrl))" Disabled="State.IsPrerendering">Buy</MudButton>
-                                                <img src="@($"/images/app/{State.App.Id}/markets/{item.BuyFrom.ToString().ToLower()}.png")" alt="@item.BuyFrom.GetDisplayName()" title="@item.BuyFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
-                                                <span>@State.Currency.ToPriceString(item.BuyTotal)</span>
-                                                @if (State.Profile.ItemIncludeMarketFees && item.BuyFee != 0)
-                                                {
-                                                    <MudTooltip>
-                                                        <TooltipContent>
-                                                            @if (item.BuyFee > 0)
-                                                            {
-                                                                <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimated fees charged by @item.BuyFrom.GetDisplayName()</span>
-                                                            }
-                                                            else
-                                                            {
-                                                                <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimate discounts gained by purchasing @item.BuyFrom.GetDisplayName() balance</span>
-                                                            }
-                                                        </TooltipContent>
-                                                        <ChildContent>
-                                                            <i class="fa fa-fw fa-comment-dollar"></i>
-                                                        </ChildContent>
-                                                    </MudTooltip>
-                                                }
-                                                @if (GetTimeSinceLastMarketPriceUpdate(item.BuyFrom) != null)
-                                                {
-                                                    <small class="mud-secondary-text"> @GetTimeSinceLastMarketPriceUpdate(item.BuyFrom).Value.ToDurationString(maxGranularity: 2, prefix: "price checked", suffix: "ago") </small>
-                                                }
-                                            </MudText>
-                                        </td>
-                                        <th class="pa-0">
-                                            <i class="fa fa-fw fa-arrow-right"></i>
-                                        </th>
-                                        <td>
-                                            <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
-                                                <MudButton Variant="Variant.Filled" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="Size.Small" OnClick="@((_) => ViewMarketItem(item.AppId, item.Name))" Disabled="State.IsPrerendering">@(SellNow == true ? "Sell" : "List")</MudButton>
-                                                <img src="@($"/images/app/{State.App.Id}/markets/{item.SellTo.ToString().ToLower()}.png")" alt="@item.BuyFrom.GetDisplayName()" title="@item.BuyFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
-                                                <span>
-                                                    <span>@State.Currency.ToPriceString(item.SellPrice)</span>
-                                                    @if (SellNow != true)
+                                            @foreach (var marketType in State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()))
+                                            {
+                                                <MudSelectItem Value="@((MarketType?)marketType)">
+                                                    <div class="d-flex justify-start align-center">
+                                                    <span>Buy it from </span>
+                                                        <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mr-2" style="width:1.5em; height:1.5em" />
+                                                    <span><strong>@marketType.GetDisplayName()</strong></span>
+                                                    </div>
+                                                </MudSelectItem>
+                                            }
+                                        </MudSelect>
+                                    </th>
+                                    <th class="pa-0">
+                                        <i class="fa fa-fw fa-arrow-right"></i>
+                                    </th>
+                                    <th>
+                                        <MudSelect T="bool?" Value="@SellNow" ValueChanged="OnSellNowChanged" Margin="Margin.None" Dense="true" FullWidth="true" Class="mud-input-full-height mud-input-transparent ma-0" Disabled="State.IsPrerendering">
+                                            <MudSelectItem Value="@((bool?)true)">
+                                                <span><strong>Sell it now</strong> for quick profit</span>
+                                            </MudSelectItem>
+                                            <MudSelectItem Value="@((bool?)false)">
+                                                <span><strong>List it now</strong> and <strong>sell later</strong> for maximum profit</span>
+                                            </MudSelectItem>
+                                        </MudSelect>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <Virtualize @ref="VirtualiseMarketFlips" ItemsProvider="LoadMarketFlips" Context="item" SpacerElement="tr">
+                                    <ItemContent>
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex flex-row justify-start align-center clickable hover-zoom" @onclick="@(() => ShowItemDetailsDialog(item.Name, item.Id.ToString()))">
+                                                    <img src="@item.IconUrl" class="mr-2" style="width:32px; height:32px;" />
+                                                    <MudText Typo="Typo.body2">@item.Name</MudText>
+                                                    @if (item.IsBeingManipulated)
                                                     {
-                                                        <span class="mud-secondary-text"> then wait <i class="fa fa-fw fa-clock"></i> </span>
+                                                        <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Warning" Size="MudBlazor.Size.Small" Icon="fas fa-fw fa-exclamation-triangle" Text="Price Manipulation" title="@($"It is suspected that this items price is being manipulated on the market because {item.ManipulationReason.FirstCharToLower()}")" Class="ml-2" />
                                                     }
-                                                    <span class="mud-secondary-text"> for a</span> <span class="@(item.IsBeingManipulated ? "mud-warning-text" : "mud-success-text")">@State.Currency.ToPriceString(item.SellProfit)</span>
-                                                </span>
-                                                <MudChip Variant="Variant.Text" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="@Size.Small" Text="@($"{item.SellProfit.ToPercentageString(item.BuyTotal) ?? "0%"}")" />
-                                                <span><span class="mud-secondary-text">profit @(State.Profile.ItemIncludeMarketFees ? "after" : "before") fees</span></span>
-                                            </MudText>
-                                        </td>
-                                    </tr>
-                                </ItemContent>
-                                <Placeholder>
-                                    <tr>
-                                        <td>
-                                            <div class="d-flex flex-row justify-start align-center">
-                                                <MudProgressCircular Indeterminate="true" Class="mr-1" Style="width:32px; height:32px;" />
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Loading...</MudText>
-                                            </div>
-                                        </td>
-                                        <td>—</td>
-                                        <td></td>
-                                        <td>—</td>
-                                    </tr>
-                                </Placeholder>
-                            </Virtualize>
-                        </tbody>
-                    </MudSimpleTable>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
+                                                    <MudButton Variant="Variant.Filled" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="Size.Small" OnClick="@((_) => BuyItem(item.BuyUrl))" Disabled="State.IsPrerendering">Buy</MudButton>
+                                                    <img src="@($"/images/app/{State.App.Id}/markets/{item.BuyFrom.ToString().ToLower()}.png")" alt="@item.BuyFrom.GetDisplayName()" title="@item.BuyFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
+                                                    <span>@State.Currency.ToPriceString(item.BuyTotal)</span>
+                                                    @if (State.Profile.ItemIncludeMarketFees && item.BuyFee != 0)
+                                                    {
+                                                        <MudTooltip>
+                                                            <TooltipContent>
+                                                                @if (item.BuyFee > 0)
+                                                                {
+                                                                    <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimated fees charged by @item.BuyFrom.GetDisplayName()</span>
+                                                                }
+                                                                else
+                                                                {
+                                                                    <span>Price includes @State.Currency.ToPriceString(item.BuyFee) in estimate discounts gained by purchasing @item.BuyFrom.GetDisplayName() balance</span>
+                                                                }
+                                                            </TooltipContent>
+                                                            <ChildContent>
+                                                                <i class="fa fa-fw fa-comment-dollar"></i>
+                                                            </ChildContent>
+                                                        </MudTooltip>
+                                                    }
+                                                    @if (GetTimeSinceLastMarketPriceUpdate(item.BuyFrom) != null)
+                                                    {
+                                                        <small class="mud-secondary-text"> @GetTimeSinceLastMarketPriceUpdate(item.BuyFrom).Value.ToDurationString(maxGranularity: 2, prefix: "price checked", suffix: "ago") </small>
+                                                    }
+                                                </MudText>
+                                            </td>
+                                            <th class="pa-0">
+                                                <i class="fa fa-fw fa-arrow-right"></i>
+                                            </th>
+                                            <td>
+                                                <MudText Typo="Typo.body2" Class="no-wrap d-flex align-center gap-1">
+                                                    <MudButton Variant="Variant.Filled" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="Size.Small" OnClick="@((_) => ViewMarketItem(item.AppId, item.Name))" Disabled="State.IsPrerendering">@(SellNow == true ? "Sell" : "List")</MudButton>
+                                                    <img src="@($"/images/app/{State.App.Id}/markets/{item.SellTo.ToString().ToLower()}.png")" alt="@item.BuyFrom.GetDisplayName()" title="@item.BuyFrom.GetDisplayName()" class="mx-2" style="width:1.5em; height:1.5em" />
+                                                    <span>
+                                                        <span>@State.Currency.ToPriceString(item.SellPrice)</span>
+                                                        @if (SellNow != true)
+                                                        {
+                                                            <span class="mud-secondary-text"> then wait <i class="fa fa-fw fa-clock"></i> </span>
+                                                        }
+                                                        <span class="mud-secondary-text"> for a</span> <span class="@(item.IsBeingManipulated ? "mud-warning-text" : "mud-success-text")">@State.Currency.ToPriceString(item.SellProfit)</span>
+                                                    </span>
+                                                    <MudChip Variant="Variant.Text" Color="@(item.IsBeingManipulated ? Color.Warning : Color.Success)" Size="@Size.Small" Text="@($"{item.SellProfit.ToPercentageString(item.BuyTotal) ?? "0%"}")" />
+                                                    <span><span class="mud-secondary-text">profit @(State.Profile.ItemIncludeMarketFees ? "after" : "before") fees</span></span>
+                                                </MudText>
+                                            </td>
+                                        </tr>
+                                    </ItemContent>
+                                    <Placeholder>
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex flex-row justify-start align-center">
+                                                    <MudProgressCircular Indeterminate="true" Class="mr-1" Style="width:32px; height:32px;" />
+                                                    <MudText Typo="Typo.body2" Color="Color.Secondary">Loading...</MudText>
+                                                </div>
+                                            </td>
+                                            <td>—</td>
+                                            <td></td>
+                                            <td>—</td>
+                                        </tr>
+                                    </Placeholder>
+                                </Virtualize>
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                    else
+                    {
+                        <Alert Severity="Severity.Normal" Icon="fas fa-fw fa-shop mr-2" Title="No third-party markets enabled" SubTitle="To use this feature, enable at least one third-party market in your profile preferences." />
+                    }
                 </AnalyticsPanel>
             </MudTabPanel>
 

--- a/SCMM.Web.Client/Pages/Statistics/StatisticsPage.razor
+++ b/SCMM.Web.Client/Pages/Statistics/StatisticsPage.razor
@@ -4,7 +4,7 @@
 @inject AppState State
 
 <PageContainer Title="@($"{State?.App?.Name} Market Statistics")">
-    <MudTabs Elevation="0" Class="mud-tabs-transparent mt-n3">
+    <MudTabs Elevation="0" KeepPanelsAlive="false" Class="mud-tabs-transparent mt-n3">
         <ChildContent>
             <MudTabPanel Icon="fas fa-fw fa-balance-scale-right mr-3" Text="@($"{State.App.Name} Market")" Disabled="State.IsPrerendering">
                 <StatisticsMarketPanel />

--- a/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
+++ b/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
@@ -41,7 +41,7 @@
         <ChildContent>
             @if (IsAnalyticsPanelOpen)
             {
-                <MudTabs @bind-ActivePanelIndex="AnalyticsPanelIndex" Rounded="true" Centered="true" PanelClass="ma-2">
+                <MudTabs @bind-ActivePanelIndex="AnalyticsPanelIndex" Rounded="true" Centered="true" KeepPanelsAlive="false" PanelClass="ma-2">
                     @if (Store?.Start != null)
                     {
                         <MudTabPanel Icon="fas fa-fw fa-trophy mr-2" Text="Top Selling Items" Disabled="@(Store?.Items?.Any() != true || TopSellers?.Any() != true)">

--- a/SCMM.Web.Client/Pages/Store/StorePage.razor
+++ b/SCMM.Web.Client/Pages/Store/StorePage.razor
@@ -29,7 +29,7 @@
 }
 else if (StoreList.Any())
 {
-    <MudTabs Elevation="0" Position="MudBlazor.Position.Bottom" ActivePanelIndex="StoreIndex" ActivePanelIndexChanged="OnSelectedStoreChanged" Class="mud-tabs-transparent">
+    <MudTabs Elevation="0" Position="MudBlazor.Position.Bottom" ActivePanelIndex="StoreIndex" ActivePanelIndexChanged="OnSelectedStoreChanged" KeepPanelsAlive="false" Class="mud-tabs-transparent">
         <ChildContent>
 		    @foreach (var store in StoreList)
             {

--- a/SCMM.Web.Client/Pages/User/SettingsPage.razor
+++ b/SCMM.Web.Client/Pages/User/SettingsPage.razor
@@ -16,7 +16,7 @@
         <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mt-n3 mb-2 mx-n6" />
     }
 
-    <MudTabs Elevation="0" Class="mud-tabs-transparent">
+    <MudTabs @bind-ActivePanelIndex="PanelIndex" Elevation="0" KeepPanelsAlive="false" Class="mud-tabs-transparent">
         <MudTabPanel Icon="fas fa-fw fa-user mr-2" Text="Profile" Disabled="State.IsPrerendering">
             <MudGrid Spacing="3">
                 <MudItem xs="12">
@@ -128,7 +128,7 @@
                         <MudCardHeader>
                             <CardHeaderContent>
                                 <MudText Typo="@MudBlazor.Typo.h6" Color="MudBlazor.Color.Default">
-                                    <i class="fas fa-fw fa-star mr-2"></i><span>Customisation</span>
+                                    <i class="fas fa-fw fa-star mr-2"></i><span>Website Customisation</span>
                                 </MudText>
                             </CardHeaderContent>
                         </MudCardHeader>
@@ -144,13 +144,18 @@
                                     </MudSelect>
                                 </Preference>
                                 <Preference Title="Market Types" 
-                                            Description="Which third-party markets are shown when displaying item prices.">
+                                            Description="Which third-party markets are shown when displaying item prices. If you don't use third-party markets, de-select all markets to force the use of Steam market prices only.">
                                     <MudSelect T="MarketType" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="false" Class="ma-0" Disabled="State.IsPrerendering"
                                                @bind-SelectedValues="@SelectedMarketTypes" ToStringFunc="@((x) => x.GetDisplayName())" OnClose="@((x) => UpdateProfile())"
-                                               MultiSelection="true" MultiSelectionTextFunc="@(new Func<List<string>, string>(x => x.Count > 0 ? String.Join(", ", x) : "No third-party markets"))">
-                                        @foreach (var value in Enum.GetValues<MarketType>().Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()).OrderBy(x => x.ToString()))
+                                               MultiSelection="true" MultiSelectionTextFunc="@(new Func<List<string>, string>(x => x.Count > 0 ? String.Join(", ", x) : "Do not show third-party markets"))">
+                                        @foreach (var marketType in Enum.GetValues<MarketType>().Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()).OrderBy(x => x.ToString()))
                                         {
-                                            <MudSelectItem Value="@value">@value.GetDisplayName()</MudSelectItem>
+                                            <MudSelectItem Value="@marketType">
+                                                <div class="d-flex justify-start align-center">
+                                                    <img src="@($"/images/app/{State.App.Id}/markets/{marketType.ToString().ToLower()}.png")" class="mr-2" style="width:1.5em; height:1.5em" />
+                                                    <span>@marketType.GetDisplayName()</span>
+                                                </div>
+                                            </MudSelectItem>
                                         }
                                     </MudSelect>
                                 </Preference>
@@ -210,112 +215,7 @@
                 </MudItem>
             </MudGrid>
         </MudTabPanel>
-        <MudTabPanel Icon="fas fa-fw fa-bell mr-4" Text="Notifications" Disabled="State.IsPrerendering">
-            <MudGrid Spacing="3">
-                <MudItem xs="12">
-                    <MudCard class="full-height d-flex flex-column mud-card">
-                        <MudCardHeader>
-                            <CardHeaderContent>
-                                <MudText Typo="@MudBlazor.Typo.h6" Color="MudBlazor.Color.Default">
-                                    <i class="fas fa-fw fa-bell mr-2"></i><span>Notifications</span>
-                                </MudText>
-                            </CardHeaderContent>
-                        </MudCardHeader>
-                        <MudCardContent class="pt-0">
-                            <MudGrid Spacing="4">
-                                <Preference Title="New Workshop Item Submission" 
-                                            Description="Be notified when an accepted item author submits a new item to the workshop. Items from accepted authors are generally the highest quality workshop submissions. Recommended if you like to stay up to date with the latest item submissions that have the potentional to be accepted in-game.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="New Workshop Collection Submission" 
-                                            Description="Be notifieid when a accepted item collection gets continued with a new workshop submission. Recommended if you like to stay up to date with ermering collections and continuations.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="New Store Items" 
-                                            Description="Be notified when new items are released to the store. This generally happens every Thursday around 8PM UTC, exact times vary week to week.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="New Store Video" 
-                                            Description="Be notified when a new community video featuring the item store has been uploaded. Recommended if you like to watch commentary about the weeks store items.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="New Market Items" 
-                                            Description="Be notified when new items are release to the Steam Community Market. This generally happens every Thursday at 12AM UTC and 8PM UTC (when the item store updates). Recommended if you prefer to buy items from the market and want to get a low buy order in early.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="Item Updated" 
-                                            Description="@($"Be notified when accepted items are updated. This doesn't happen often, but occasionally {State.App.PublisherName} will modify or fix items after they have been accepted in-game. In rare instances, the appearance of items can be modified. Recommended if you'd like to stay up to day with potential changes to in-game items.")">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="Item Market High" 
-                                            Description="Be notified when an item reaches a new all-time high price on the Steam Community Market. Recommended if you like to sell items as they peak in price. This notification has a 24hr cool-down to avoid spam.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                                <Preference Title="Item Market Low" 
-                                            Description="Be notified when an item reaches a new all-time low price on the Steam Community Market. Recommended if you like to buy items while at their cheapest. This notification has a 24hr cool-down to avoid spam.">
-                                    <MudSelect T="string" Value="@("Disabled")" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="true" Class="ma-0" Disabled="State.IsPrerendering || true">
-                                       <MudSelectItem Value="@("Disabled")" />
-                                    </MudSelect>
-                                </Preference>
-                            </MudGrid>
-                        </MudCardContent>
-                    </MudCard>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudCard class="full-height d-flex flex-column mud-card">
-                        <MudCardHeader>
-                            <CardHeaderContent>
-                                <MudText Typo="@MudBlazor.Typo.h6" Color="MudBlazor.Color.Default">
-                                    <i class="fab fa-fw fa-discord mr-2"></i><span>Discord</span>
-                                </MudText>
-                            </CardHeaderContent>
-                        </MudCardHeader>
-                        <MudCardContent class="py-0">
-                            <MudAlert Severity="MudBlazor.Severity.Normal" ContentAlignment="HorizontalAlignment.Center" NoIcon="true" Class="pa-8">Empty</MudAlert>
-                        </MudCardContent>
-                        <MudCardActions class="pa-4">
-                            <MudButton Variant="MudBlazor.Variant.Outlined" Color="MudBlazor.Color.Primary" StartIcon="fas fa-fw fa-link" Disabled="State.IsPrerendering || true">
-                                Link Discord
-                            </MudButton>
-                        </MudCardActions>
-                    </MudCard>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudCard class="full-height d-flex flex-column mud-card">
-                        <MudCardHeader>
-                            <CardHeaderContent>
-                                <MudText Typo="@MudBlazor.Typo.h6" Color="MudBlazor.Color.Default" Class="d-flex align-center">
-                                    <WebHookIcon /><span class="ml-2">Webhooks</span>
-                                </MudText>
-                            </CardHeaderContent>
-                        </MudCardHeader>
-                        <MudCardContent class="py-0">
-                            <MudAlert Severity="MudBlazor.Severity.Normal" ContentAlignment="HorizontalAlignment.Center" NoIcon="true" Class="pa-8">Empty</MudAlert>
-                        </MudCardContent>
-                        <MudCardActions class="pa-4">
-                            <MudButton Variant="MudBlazor.Variant.Outlined" Color="MudBlazor.Color.Primary" StartIcon="fas fa-fw fa-plus" Disabled="State.IsPrerendering || true">
-                                Add Webhook
-                            </MudButton>
-                        </MudCardActions>
-                    </MudCard>
-                </MudItem>
-            </MudGrid>
-        </MudTabPanel>
-        <MudTabPanel Icon="fas fa-fw fa-database mr-3" Text="Data" Disabled="State.IsPrerendering">
+        <MudTabPanel Icon="fas fa-fw fa-database mr-3" Text="Account Data" Disabled="State.IsPrerendering">
             <MudGrid Spacing="3">
                 <MudItem xs="12">
                     <MudCard class="full-height d-flex flex-column mud-card">
@@ -369,10 +269,16 @@
 
 @code {
 
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string Panel { get; set; }
+
+    private int PanelIndex { get; set; }
+
     private bool IsUpdating { get; set; }
 
     private UpdateProfileCommand Update { get; set; }
-    
+
     private IEnumerable<MarketType> SelectedMarketTypes { get; set; }
 
     private IEnumerable<ItemInfoType> SelectedItemInfoTypes { get; set; }
@@ -387,7 +293,7 @@
         }
         else 
         {
-            SelectedMarketTypes = State.Profile.MarketTypes;
+            SelectedMarketTypes = State.Profile.MarketTypes.Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()).OrderBy(x => x.ToString());
             SelectedItemInfoTypes = State.Profile.ItemInfo;
             Update = new UpdateProfileCommand()
             {
@@ -403,6 +309,19 @@
                 InventoryShowUnmarketableItems = State.Profile.InventoryShowUnmarketableItems,
                 InventoryValueMovemenDisplay = State.Profile.InventoryValueMovementDisplay
             };
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!String.IsNullOrEmpty(Panel))
+        {
+            switch(Panel)
+            {
+                case "profile": PanelIndex = 0; break;
+                case "preferences": PanelIndex = 1; break;
+                case "data": PanelIndex = 2; break;
+            }
         }
     }
 

--- a/SCMM.Web.Client/Pages/User/SettingsPage.razor
+++ b/SCMM.Web.Client/Pages/User/SettingsPage.razor
@@ -143,6 +143,17 @@
                                         }
                                     </MudSelect>
                                 </Preference>
+                                <Preference Title="Market Types" 
+                                            Description="Which third-party markets are shown when displaying item prices.">
+                                    <MudSelect T="MarketType" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="false" Class="ma-0" Disabled="State.IsPrerendering"
+                                               @bind-SelectedValues="@SelectedMarketTypes" ToStringFunc="@((x) => x.GetDisplayName())" OnClose="@((x) => UpdateProfile())"
+                                               MultiSelection="true" MultiSelectionTextFunc="@(new Func<List<string>, string>(x => x.Count > 0 ? String.Join(", ", x) : "No third-party markets"))">
+                                        @foreach (var value in Enum.GetValues<MarketType>().Where(x => x.IsEnabled() && x.IsAppSupported(State.AppId)&& !x.IsFirstParty()).OrderBy(x => x.ToString()))
+                                        {
+                                            <MudSelectItem Value="@value">@value.GetDisplayName()</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                </Preference>
                                 <Preference Title="Market 'Value'" 
                                             Description="Which data source is used to determine an items price/value.">
                                     <MudSelect T="MarketValueType" Value="@Update.MarketValue" ValueChanged="((x) => { Update.MarketValue = x; _ = UpdateProfile(); })" Margin="MudBlazor.Margin.None" Variant="MudBlazor.Variant.Outlined" FullWidth="false" Class="ma-0" Disabled="State.IsPrerendering || true">
@@ -174,15 +185,15 @@
                                 </Preference>
                                 <Preference Title="Item Market Fees" 
                                             Description="Should market sales fees be included in all resell, profit, and investment gain/loss calculations. This is recommended if you primarily sell your items on skin marketplaces (as opposed to selling for cash).">  
-                                    <MudSwitch T="bool" Checked="@Update.ItemIncludeMarketFees" CheckedChanged="((x) => { Update.ItemIncludeMarketFees = x; _ = UpdateProfile(); })" Color="Color.Primary" Class="ma-0" Disabled="State.IsPrerendering">@(Update.ItemIncludeMarketFees ? "Include" : "Exclude")</MudSwitch>
+                                    <MudSwitch T="bool" Value="@Update.ItemIncludeMarketFees" ValueChanged="((x) => { Update.ItemIncludeMarketFees = x; _ = UpdateProfile(); })" Color="Color.Primary" Class="ma-0" Disabled="State.IsPrerendering">@(Update.ItemIncludeMarketFees ? "Include" : "Exclude")</MudSwitch>
                                 </Preference>
                                 <Preference Title="Inventory Item Drops" 
                                             Description="@($"Should 'free' item drops (e.g. Twitch and {State.App.PublisherName} items) be shown when viewing item inventories and item collections.")">
-                                    <MudSwitch T="bool" Checked="@Update.InventoryShowItemDrops" CheckedChanged="((x) => { Update.InventoryShowItemDrops = x; _ = UpdateProfile(); })" Color="Color.Primary" Class="ma-0" Disabled="State.IsPrerendering">@(Update.InventoryShowItemDrops ? "Show" : "Hide")</MudSwitch>
+                                    <MudSwitch T="bool" Value="@Update.InventoryShowItemDrops" ValueChanged="((x) => { Update.InventoryShowItemDrops = x; _ = UpdateProfile(); })" Color="Color.Primary" Class="ma-0" Disabled="State.IsPrerendering">@(Update.InventoryShowItemDrops ? "Show" : "Hide")</MudSwitch>
                                 </Preference>
                                 <Preference Title="Inventory Unmarketable Items" 
                                             Description="Should unmarketable items (e.g. Permanent store and charity items) be shown when viewing item inventories and item collections.">  
-                                    <MudSwitch T="bool" Checked="@Update.InventoryShowUnmarketableItems" CheckedChanged="((x) => { Update.InventoryShowUnmarketableItems = x; _ = UpdateProfile(); })" Color="Color.Primary" Class="ma-0" Disabled="State.IsPrerendering">@(Update.InventoryShowUnmarketableItems ? "Show" : "Hide")</MudSwitch>
+                                    <MudSwitch T="bool" Value="@Update.InventoryShowUnmarketableItems" ValueChanged="((x) => { Update.InventoryShowUnmarketableItems = x; _ = UpdateProfile(); })" Color="Color.Primary" Class="ma-0" Disabled="State.IsPrerendering">@(Update.InventoryShowUnmarketableItems ? "Show" : "Hide")</MudSwitch>
                                 </Preference>
                                 <Preference Title="Inventory Value Movement Display" 
                                             Description="How should inventory value movements be shown.">  
@@ -361,6 +372,8 @@
     private bool IsUpdating { get; set; }
 
     private UpdateProfileCommand Update { get; set; }
+    
+    private IEnumerable<MarketType> SelectedMarketTypes { get; set; }
 
     private IEnumerable<ItemInfoType> SelectedItemInfoTypes { get; set; }
 
@@ -374,6 +387,7 @@
         }
         else 
         {
+            SelectedMarketTypes = State.Profile.MarketTypes;
             SelectedItemInfoTypes = State.Profile.ItemInfo;
             Update = new UpdateProfileCommand()
             {
@@ -401,6 +415,7 @@
         try 
         {
             IsUpdating = true;
+            Update.MarketTypes = SelectedMarketTypes?.ToArray();
             Update.ItemInfo = SelectedItemInfoTypes?.ToArray();
             StateHasChanged();
 

--- a/SCMM.Web.Client/SCMM.Web.Client.csproj
+++ b/SCMM.Web.Client/SCMM.Web.Client.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="BlazorIntersectionObserver" Version="3.1.0" />
     <PackageReference Include="Markdig" Version="0.34.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.15" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="MudBlazor" Version="6.11.1" />
+    <PackageReference Include="MudBlazor" Version="6.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="Syncfusion.Blazor.Themes" Version="23.2.7" />
 	<PackageReference Include="Syncfusion.Blazor.Charts" Version="23.2.7" />

--- a/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
+++ b/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
@@ -48,7 +48,7 @@
                         @if (Item.WorkshopFileId != null)
                         {
                             <div class="d-flex align-center justify-center full-width item-preview-controls">
-                                <MudButtonGroup Color="Color.Default" Size="Size.Medium" Variant="Variant.Filled" DisableElevation="true">
+                                <MudButtonGroup Color="Color.Default" Size="MudBlazor.Size.Medium" Variant="Variant.Filled" DisableElevation="true">
                                     <MudTooltip Text="View the workshop page">
                                         <MudButton OnClick="@ViewItemWorkshopPage" Disabled="Item.WorkshopFileId == null || State.IsPrerendering">
                                             <i class="fas fa-fw fa-tools mr-1"></i>
@@ -578,7 +578,7 @@
                             <MudTimeline>
                                 @foreach (var timelineEvent in GetTimelineEvents().OrderByDescending(x => x.Timestamp))
                                 {
-                                    <MudTimelineItem Color="@timelineEvent.Color" TimelineAlign="TimelineAlign.End" Size="Size.Medium" Elevation="25">
+                                    <MudTimelineItem Color="@timelineEvent.Color" TimelineAlign="TimelineAlign.End" Size="MudBlazor.Size.Medium" Elevation="25">
                                         <ItemOpposite>
                                             <MudText Typo="Typo.body1" Color="@timelineEvent.Color">@timelineEvent.Timestamp.ToString("d")</MudText>
                                             <MudText Typo="Typo.body2" Color="Color.Secondary">@((DateTimeOffset.Now - timelineEvent.Timestamp).ToDurationString(maxGranularity: 1, suffix: "ago"))</MudText>
@@ -990,7 +990,7 @@
                                                             @foreach (var item in itemGroup)
                                                             {
                                                                 <MudTooltip Text="@($"{item.Name} was accepted")">
-                                                                    <MudChip Size="Size.Small" Class="pa-1" Style="height:auto">
+                                                                    <MudChip Size="MudBlazor.Size.Small" Class="pa-1" Style="height:auto">
                                                                         <div class="hover-zoom hover-zoom-extra">
                                                                             <img src="@item.IconUrl" onerror="@($"this.onerror=null; this.src='/images/app/{State.AppId}/items/{item.ItemType.RustItemTypeToShortName()}.png'")" alt="@item.Name" style="width:3em; height:3em" />
                                                                         </div>

--- a/SCMM.Web.Client/Shared/Layout/AppBarProfileControls.razor
+++ b/SCMM.Web.Client/Shared/Layout/AppBarProfileControls.razor
@@ -38,7 +38,7 @@
                 <MudDivider />
                 <MudMenuItem Href="@($"/inventory/{State.Profile.SteamId}?panel=items")" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-th" ></i>
-                    <span>Item Inventory</span>
+                    <span>Your Items</span>
                     @if (InventoryTotals?.Items > 0)
                     {
                         <span class="mud-secondary-text"> (@InventoryTotals.Items.ToQuantityString())</span>
@@ -46,11 +46,11 @@
                 </MudMenuItem>
                 <MudMenuItem Href="@($"/inventory/{State.Profile.SteamId}?panel=collections")" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-tshirt" ></i>
-                    <span>Item Collections</span>
+                    <span>Your Collections</span>
                 </MudMenuItem>
                 <MudMenuItem Href="@($"/inventory/{State.Profile.SteamId}?panel=market")" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-balance-scale-left" ></i>
-                    <span>Market Performance</span>
+                    <span>Your Market Performance</span>
                     @if (InventoryTotals?.MarketValue > 0)
                     {
                         <span class="mud-secondary-text"> (@State.Currency?.ToPriceString(InventoryTotals.MarketValue))</span>
@@ -58,32 +58,24 @@
                 </MudMenuItem>
                 <MudMenuItem Href="@($"/inventory/{State.Profile.SteamId}?panel=investment")" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-hand-holding-usd" ></i>
-                    <span>Investment Performance</span>
+                    <span>Your Investments</span>
                     @if (InventoryTotals?.InvestmentNetReturn > 0)
                     {
                         <span class="mud-secondary-text"> (@State.Currency?.ToPriceString(InventoryTotals.InvestmentNetReturn.Value))</span>
                     }
                 </MudMenuItem>
-                <MudMenuItem Href="@($"/inventory/{State.Profile.SteamId}?panel=statistics")" Disabled="State.IsPrerendering">
-                    <i class="fas fa-fw fa-chart-pie" ></i>
-                    <span>Inventory Statistics</span>
-                </MudMenuItem>
                 <MudDivider />
-                <MudMenuItem Href="/settings?panel=general" Disabled="State.IsPrerendering">
+                <MudMenuItem Href="/settings?panel=profile" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-user" ></i>
-                    <span>Profile</span>
+                    <span>Your Profile</span>
                 </MudMenuItem>
                 <MudMenuItem Href="/settings?panel=preferences" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-sliders-h" ></i>
-                    <span>Preferences</span>
-                </MudMenuItem>
-                <MudMenuItem Href="/settings?panel=notifications" Disabled="State.IsPrerendering">
-                    <i class="fas fa-fw fa-bell" ></i>
-                    <span>Notifications</span>
+                    <span>Your Preferences</span>
                 </MudMenuItem>
                 <MudMenuItem Href="/settings?panel=data" Disabled="State.IsPrerendering">
                     <i class="fas fa-fw fa-database" ></i>
-                    <span>Your Data</span>
+                    <span>Your Account Data</span>
                 </MudMenuItem>
                 <MudDivider />
                 <MudMenuItem OnTouch="NavigateToSignOut" OnClick="NavigateToSignOut" Disabled="State.IsPrerendering">

--- a/SCMM.Web.Data.Models/UI/Profile/MyProfileDTO.cs
+++ b/SCMM.Web.Data.Models/UI/Profile/MyProfileDTO.cs
@@ -23,6 +23,8 @@ namespace SCMM.Web.Data.Models.UI.Profile
 
         public StoreTopSellerRankingType StoreTopSellers { get; set; }
 
+        public MarketType[] MarketTypes { get; set; }
+
         public MarketValueType MarketValue { get; set; }
 
         public ItemInfoType[] ItemInfo { get; set; }

--- a/SCMM.Web.Data.Models/UI/Profile/UpdateProfileCommand.cs
+++ b/SCMM.Web.Data.Models/UI/Profile/UpdateProfileCommand.cs
@@ -16,6 +16,8 @@ namespace SCMM.Web.Data.Models.UI.Profile
 
         public StoreTopSellerRankingType StoreTopSellers { get; set; }
 
+        public MarketType[] MarketTypes { get; set; }
+
         public MarketValueType MarketValue { get; set; }
 
         public ItemInfoType[] ItemInfo { get; set; }

--- a/SCMM.Web.Server/API/Controllers/ProfileController.cs
+++ b/SCMM.Web.Server/API/Controllers/ProfileController.cs
@@ -141,6 +141,7 @@ namespace SCMM.Web.Server.API.Controllers
                 profile.Currency = _db.SteamCurrencies.FirstOrDefault(x => x.Name == command.Currency);
             }
             profile.StoreTopSellers = command.StoreTopSellers;
+            profile.MarketTypes = command.MarketTypes;
             profile.MarketValue = command.MarketValue;
             profile.ItemInfo = command.ItemInfo;
             profile.ItemInfoWebsite = command.ItemInfoWebsite;

--- a/SCMM.Web.Server/Extensions/AutoMapperConfigurationExtensions.cs
+++ b/SCMM.Web.Server/Extensions/AutoMapperConfigurationExtensions.cs
@@ -6,6 +6,7 @@ using SCMM.Steam.Data.Store;
 using SCMM.Web.Data.Models.UI.App;
 using SCMM.Web.Data.Models.UI.Currency;
 using SCMM.Web.Data.Models.UI.Language;
+using SCMM.Web.Data.Models.UI.Profile;
 using System.Linq.Expressions;
 
 namespace SCMM.Web.Server.Extensions
@@ -13,6 +14,7 @@ namespace SCMM.Web.Server.Extensions
     public static class AutoMapperConfigurationExtensions
     {
         public const string ContextKeyUser = "user";
+        public const string ContextKeyProfile = "profile";
         public const string ContextKeyLanguage = "language";
         public const string ContextKeyCurrency = "currency";
         public const string ContextKeyApp = "app";
@@ -190,7 +192,8 @@ namespace SCMM.Web.Server.Extensions
                         return default;
                     }
 
-                    var price = assetDescription.GetCheapestBuyPrice(currency);
+                    var profile = (MyProfileDTO)context.Items.GetOrDefault(ContextKeyProfile);
+                    var price = assetDescription.GetCheapestBuyPrice(currency, profile?.MarketTypes);
                     if (price == null)
                     {
                         return default;
@@ -228,8 +231,10 @@ namespace SCMM.Web.Server.Extensions
                         return null;
                     }
 
-                    return assetDescription.GetBuyPrices(currency)
+                    var profile = (MyProfileDTO)context.Items.GetOrDefault(ContextKeyProfile);
+                    return assetDescription.GetBuyPrices(currency, profile?.MarketTypes)
                         .Where(x => includeThirdPartyMarkets || x.IsFirstPartyMarket)
+                        .Where(x => x.IsFirstPartyMarket || (profile == null || profile.MarketTypes.Contains(x.MarketType)))
                         .OrderBy(x => x.Price)
                         .ToList();
                 }

--- a/SCMM.Web.Server/Extensions/AutoMapperExtensions.cs
+++ b/SCMM.Web.Server/Extensions/AutoMapperExtensions.cs
@@ -1,28 +1,34 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
+using SCMM.Steam.Data.Store;
+using SCMM.Web.Data.Models.UI.Profile;
 
 namespace SCMM.Web.Server.Extensions
 {
     public static class AutoMapperExtensions
     {
-        public static IList<T2> Map<T1, T2>(this IMapper mapper, IEnumerable<T1> query, ControllerBase controller)
+        public static IList<T2> Map<T1, T2>(this IMapper mapper, IEnumerable<T1> query, ControllerBase controller, MyProfileDTO profile = null)
         {
             return query.ToList()
-                .Select(x => mapper.Map<T1, T2>(x, opt => opt.AddContext(controller)))
+                .Select(x => mapper.Map<T1, T2>(x, opt => opt.AddContext(controller, profile)))
                 .ToList();
         }
 
-        public static T2 Map<T1, T2>(this IMapper mapper, T1 obj, ControllerBase controller)
+        public static T2 Map<T1, T2>(this IMapper mapper, T1 obj, ControllerBase controller, MyProfileDTO profile = null)
         {
-            return mapper.Map<T1, T2>(obj, opt => opt.AddContext(controller));
+            return mapper.Map<T1, T2>(obj, opt => opt.AddContext(controller, profile));
         }
 
-        private static IMappingOperationOptions AddContext(this IMappingOperationOptions opt, ControllerBase controller)
+        private static IMappingOperationOptions AddContext(this IMappingOperationOptions opt, ControllerBase controller, MyProfileDTO profile = null)
         {
             opt.Items[AutoMapperConfigurationExtensions.ContextKeyUser] = controller.User;
             opt.Items[AutoMapperConfigurationExtensions.ContextKeyLanguage] = controller.Language();
             opt.Items[AutoMapperConfigurationExtensions.ContextKeyCurrency] = controller.Currency();
             opt.Items[AutoMapperConfigurationExtensions.ContextKeyApp] = controller.App();
+            if (profile != null)
+            {
+                opt.Items[AutoMapperConfigurationExtensions.ContextKeyProfile] = profile;
+            }
             return opt;
         }
     }

--- a/SCMM.Web.Server/SCMM.Web.Server.csproj
+++ b/SCMM.Web.Server/SCMM.Web.Server.csproj
@@ -18,10 +18,10 @@
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="CommandQuery.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.15" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.14" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.15" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/SCMM.Web.Server/SCMM.Web.Server.xml
+++ b/SCMM.Web.Server/SCMM.Web.Server.xml
@@ -498,6 +498,21 @@
             <response code="200">List of market index fund values grouped/keyed per day by UTC date.</response>
             <response code="500">If the server encountered a technical issue completing the request.</response>
         </member>
+        <member name="M:SCMM.Web.Server.API.Controllers.StatisticsController.GetMarketCheapestListings(System.String,System.Nullable{SCMM.Steam.Data.Models.Enums.MarketType},System.Nullable{System.Decimal},System.Int32,System.Int32)">
+            <summary>
+            Get the cheapeast market listing for items
+            </summary>
+            <remarks>
+            The currency used to represent monetary values can be changed by defining <code>Currency</code> in the request headers or query string and setting it to a supported three letter ISO 4217 currency code (e.g. 'USD').
+            </remarks>
+            <param name="filter">Optional search filter. Matches against item name, type, or collection</param>
+            <param name="market">Optional market type filter. If specified, only items from this market will be returned</param>
+            <param name="minimumInvestmentReliability"></param>
+            <param name="start">Return items starting at this specific index (pagination)</param>
+            <param name="count">Number items to be returned (can be less if not enough data). Max 100.</param>
+            <response code="200">Paginated list of items matching the request parameters.</response>
+            <response code="500">If the server encountered a technical issue completing the request.</response>
+        </member>
         <member name="M:SCMM.Web.Server.API.Controllers.StatisticsController.GetMarketFlips(System.String,System.Nullable{SCMM.Steam.Data.Models.Enums.MarketType},System.Nullable{System.Decimal},System.Boolean,System.Int32,System.Int32)">
             <summary>
             Get items that can be instantly flipped on to the Steam Community Market for profit
@@ -514,24 +529,9 @@
             <response code="200">Paginated list of items matching the request parameters.</response>
             <response code="500">If the server encountered a technical issue completing the request.</response>
         </member>
-        <member name="M:SCMM.Web.Server.API.Controllers.StatisticsController.GetMarketCheapestListings(System.String,System.Nullable{SCMM.Steam.Data.Models.Enums.MarketType},System.Nullable{System.Decimal},System.Int32,System.Int32)">
-            <summary>
-            Get the cheapeast market listing for items
-            </summary>
-            <remarks>
-            The currency used to represent monetary values can be changed by defining <code>Currency</code> in the request headers or query string and setting it to a supported three letter ISO 4217 currency code (e.g. 'USD').
-            </remarks>
-            <param name="filter">Optional search filter. Matches against item name, type, or collection</param>
-            <param name="market">Optional market type filter. If specified, only items from this market will be returned</param>
-            <param name="minimumInvestmentReliability"></param>
-            <param name="start">Return items starting at this specific index (pagination)</param>
-            <param name="count">Number items to be returned (can be less if not enough data). Max 100.</param>
-            <response code="200">Paginated list of items matching the request parameters.</response>
-            <response code="500">If the server encountered a technical issue completing the request.</response>
-        </member>
         <member name="M:SCMM.Web.Server.API.Controllers.StatisticsController.GetCraftingCheapestComponentCosts(System.Int32,System.Int32)">
             <summary>
-            Get the chespest method of aquiring crafting components, sorted by lowest cost
+            Get the cheapest method of acquiring crafting components, sorted by lowest cost
             </summary>
             <param name="start">Return items starting at this specific index (pagination)</param>
             <param name="count">Number items to be returned (can be less if not enough data). Max 100.</param>

--- a/SCMM.Worker.Server/SCMM.Worker.Server.csproj
+++ b/SCMM.Worker.Server/SCMM.Worker.Server.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
 	<PackageReference Include="CommandQuery.DependencyInjection" Version="1.0.0" />
-	<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.14" />
+	<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.15" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 	<PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />


### PR DESCRIPTION
## Changes
- Cleaned up market type affiliate codes and links
- Added new profile preference for determining which third-party market prices are shown
- Market prices from third-party markets no longer shown unless enabled in profile preferences
- Fixed MudBlazor "'Checked' is obsolete, use 'Value' instead" warning

### Profile preferences
New multi-select list to select desired market types.
![image](https://github.com/Steam-Community-Market-Manager/SCMM/assets/123988/0ef04f73-4b7f-4993-8fa0-cf83d2c3c4c4)

### Market deals page
If no market types are enabled, a warning is shown.
![image](https://github.com/Steam-Community-Market-Manager/SCMM/assets/123988/8dc5abd4-e0ef-4f6e-84f2-c54b7d267804)
