### PR TITLE
Add store price tracking job

### DIFF
--- a/SCMM.Steam.Data.Models/Enums/SteamAppFeatureFlags.cs
+++ b/SCMM.Steam.Data.Models/Enums/SteamAppFeatureFlags.cs
@@ -12,7 +12,7 @@
         ItemWorkshopAcceptedTracking = 0x400,
 
         ItemStore = 0x10000,
-        ItemStoreBrowser = 0x20000,
+        ItemStoreWebBrowser = 0x20000,
         ItemStorePriceTracking = 0x40000,
         ItemStoreMediaTracking = 0x80000,
         ItemStorePersistent = 0x100000,

--- a/SCMM.Steam.Data.Store/Migrations/20240120233758_SteamAppFeatureFlagRefactor.cs
+++ b/SCMM.Steam.Data.Store/Migrations/20240120233758_SteamAppFeatureFlagRefactor.cs
@@ -50,6 +50,7 @@ namespace SCMM.Steam.Data.Store.Migrations
 
             var csgoFeatureFlags = (
                 SteamAppFeatureFlags.ItemStore |
+                SteamAppFeatureFlags.ItemStorePriceTracking |
                 SteamAppFeatureFlags.ItemMarket |
                 SteamAppFeatureFlags.ItemInventory
             );
@@ -61,7 +62,8 @@ namespace SCMM.Steam.Data.Store.Migrations
                 SteamAppFeatureFlags.ItemWorkshopSubmissionTracking |
                 SteamAppFeatureFlags.ItemWorkshopAcceptedTracking |
                 SteamAppFeatureFlags.ItemStore |
-                SteamAppFeatureFlags.ItemStoreBrowser |
+                SteamAppFeatureFlags.ItemStoreWebBrowser |
+                //SteamAppFeatureFlags.ItemStorePriceTracking | // Rust gets this from item definition updates instead
                 SteamAppFeatureFlags.ItemStorePersistent |
                 SteamAppFeatureFlags.ItemStoreRotating |
                 SteamAppFeatureFlags.ItemMarket |
@@ -84,7 +86,8 @@ namespace SCMM.Steam.Data.Store.Migrations
 
             var unturnedFeatureFlags = (
                 SteamAppFeatureFlags.ItemStore |
-                SteamAppFeatureFlags.ItemStoreBrowser |
+                SteamAppFeatureFlags.ItemStoreWebBrowser |
+                SteamAppFeatureFlags.ItemStorePriceTracking |
                 SteamAppFeatureFlags.ItemMarket |
                 SteamAppFeatureFlags.ItemInventory
             );

--- a/SCMM.Steam.Data.Store/SteamAssetDescription.cs
+++ b/SCMM.Steam.Data.Store/SteamAssetDescription.cs
@@ -270,7 +270,7 @@ namespace SCMM.Steam.Data.Store
                 var buyUrl = (string)null;
                 if (!String.IsNullOrEmpty(StoreItem.SteamId) && app != null)
                 {
-                    if (app.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreBrowser))
+                    if (app.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreWebBrowser))
                     {
                         buyUrl = new SteamItemStoreDetailPageRequest()
                         {
@@ -398,7 +398,7 @@ namespace SCMM.Steam.Data.Store
                 var storeUrl = (string)null;
                 if (!String.IsNullOrEmpty(StoreItem.SteamId) && StoreItem.IsAvailable && app != null)
                 {
-                    if (app.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreBrowser))
+                    if (app.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreWebBrowser))
                     {
                         storeActionName = "View Store";
                         storeUrl = new SteamItemStoreDetailPageRequest()

--- a/SCMM.Steam.Data.Store/SteamMarketItem.cs
+++ b/SCMM.Steam.Data.Store/SteamMarketItem.cs
@@ -242,6 +242,11 @@ namespace SCMM.Steam.Data.Store
                 .ToDictionary(k => k.Key, v => v.Value)
             );
 
+            // What was the best buy price prior to this price update?
+            var lastBestBuyPrice = BuyPrices
+                .Where(x => x.Value.Price > 0 && x.Value.Supply != 0)
+                .Min(x => x.Value.Price);
+
             if (price?.Price > 0 && (price?.Supply == null || price?.Supply > 0))
             {
                 BuyPrices[type] = price.Value;
@@ -277,8 +282,8 @@ namespace SCMM.Steam.Data.Store
                     })
                     .MinBy(x => x.Price + x.Fee);
                 var buyNowDealHasImproved = (
-                    lowestBuyPrice.Price < BuyNowPrice &&
-                    lowestBuyPrice.Price.ToPercentage(BuyNowPrice) < 100
+                    lowestBuyPrice.Price < lastBestBuyPrice &&
+                    lowestBuyPrice.Price.ToPercentage(lastBestBuyPrice) < 100
                 );
                 BuyNowFrom = lowestBuyPrice.From;
                 BuyNowPrice = lowestBuyPrice.Price;

--- a/SCMM.Steam.Functions/Timer/CheckForNewStoreItems.cs
+++ b/SCMM.Steam.Functions/Timer/CheckForNewStoreItems.cs
@@ -1,0 +1,173 @@
+﻿using CommandQuery;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SCMM.Shared.Data.Models.Extensions;
+using SCMM.Shared.Abstractions.Messaging;
+using SCMM.Shared.API.Events;
+using SCMM.Steam.API.Commands;
+using SCMM.Steam.Client;
+using SCMM.Steam.Data.Models;
+using SCMM.Steam.Data.Models.Enums;
+using SCMM.Steam.Data.Models.WebApi.Requests.ISteamEconomy;
+using SCMM.Steam.Data.Store;
+using SCMM.Steam.Data.Store.Types;
+using System.Globalization;
+
+namespace SCMM.Steam.Functions.Timer;
+
+public class CheckForNewStoreItems
+{
+    private readonly ICommandProcessor _commandProcessor;
+    private readonly IQueryProcessor _queryProcessor;
+    private readonly SteamDbContext _steamDb;
+    private readonly SteamWebApiClient _apiClient;
+    private readonly IServiceBus _serviceBus;
+
+    public CheckForNewStoreItems(ICommandProcessor commandProcessor, IQueryProcessor queryProcessor, SteamDbContext steamDb, SteamWebApiClient apiClient, IServiceBus serviceBus)
+    {
+        _commandProcessor = commandProcessor;
+        _queryProcessor = queryProcessor;
+        _steamDb = steamDb;
+        _apiClient = apiClient;
+        _serviceBus = serviceBus;
+    }
+
+    [Function("Check-New-Store-Items")]
+    public async Task Run([TimerTrigger("0 * * * * *")] /* every minute */ TimerInfo timerInfo, FunctionContext context)
+    {
+        var logger = context.GetLogger("Check-New-Store-Items");
+
+        var apps = await _steamDb.SteamApps
+            .Where(x => x.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePriceTracking))
+            .ToArrayAsync();
+
+        foreach (var app in apps)
+        {
+            logger.LogTrace($"Checking for new item definition archives (appId: {app.SteamId})");
+
+            // Get the latest asset description prices
+            var assetPricesResponse = await _apiClient.SteamEconomyGetAssetPricesAsync(new GetAssetPricesJsonRequest()
+            {
+                AppId = uint.Parse(app.SteamId)
+            });
+            if (assetPricesResponse?.Success != true)
+            {
+                logger.LogError($"Failed to get store asset prices (appId: {app.SteamId})");
+            }
+
+            // Find the missing asset descriptions
+            var storeAssetClassIds = assetPricesResponse.Assets
+                .Where(x => !String.IsNullOrEmpty(x.ClassId))
+                .Select(x => UInt64.Parse(x.ClassId))
+                .ToArray();
+            var existingAssetClassIds = await _steamDb.SteamStoreItems
+                .Where(x => x.AppId == app.Id)
+                .Where(x => x.Description.ClassId != null)
+                .Where(x => storeAssetClassIds.Contains(x.Description.ClassId.Value))
+                .Select(x => x.Description.ClassId)
+                .ToArrayAsync();
+            var missingAssetClassIds = storeAssetClassIds
+                .Where(x => !existingAssetClassIds.Contains(x))
+                .ToArray();
+
+            if (missingAssetClassIds.Any())
+            {
+                // Prices are returned in USD by default
+                var usdCurrency = _steamDb.SteamCurrencies.FirstOrDefault(x => x.Name == Constants.SteamCurrencyUSD);
+                if (usdCurrency == null)
+                {
+                    return;
+                }
+
+                // Import any missing asset descriptions
+                foreach (var assetClassId in missingAssetClassIds)
+                {
+                    var assetPrice = assetPricesResponse.Assets.FirstOrDefault(x => x.ClassId == assetClassId.ToString());
+                    if (assetPrice == null)
+                    {
+                        continue;
+                    }
+
+                    // Import the asset description
+                    var importedAssetDescription = await _commandProcessor.ProcessWithResultAsync(new ImportSteamAssetDescriptionRequest()
+                    {
+                        AppId = UInt64.Parse(app.SteamId),
+                        AssetClassId = assetClassId,
+                    });
+
+                    // If the asset description is not yet accepted, accept it now
+                    var assetDescription = importedAssetDescription.AssetDescription;
+                    assetDescription.IsAccepted = true;
+                    if (assetDescription.TimeAccepted == null)
+                    {
+                        if (!String.IsNullOrEmpty(assetPrice.Date))
+                        {
+                            DateTimeOffset storeDate;
+                            if (DateTimeOffset.TryParseExact(assetPrice.Date, "yyyy-M-d", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out storeDate) ||
+                                DateTimeOffset.TryParseExact(assetPrice.Date, "yyyy/M/d", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out storeDate))
+                            {
+                                assetDescription.TimeAccepted = storeDate;
+                            }
+                        }
+                        else
+                        {
+                            assetDescription.TimeAccepted = DateTimeOffset.UtcNow;
+                        }
+                    }
+
+                    // Create the store item
+                    var storeItem = new SteamStoreItem()
+                    {
+                        App = app,
+                        AppId = app.Id,
+                        Description = assetDescription,
+                        DescriptionId = assetDescription.Id
+                    };
+
+                    // Set the store item price
+                    var prices = assetPrice.Prices;
+                    storeItem.UpdatePrice(
+                        usdCurrency,
+                        prices.FirstOrDefault(x => x.Key == usdCurrency?.Name).Value,
+                        new PersistablePriceDictionary(prices)
+                    );
+
+                    // Mark the store item as available
+                    storeItem.SteamId = assetPrice.Name;
+                    storeItem.IsAvailable = true;
+
+                    app.StoreItems.Add(storeItem);
+                    await _steamDb.SaveChangesAsync();
+
+                    await _serviceBus.SendMessageAsync(new StoreItemAddedMessage()
+                    {
+                        AppId = UInt64.Parse(app.SteamId),
+                        AppName = app.Name,
+                        AppIconUrl = app.IconUrl,
+                        AppColour = app.PrimaryColor,
+                        StoreId = null,
+                        StoreName = null,
+                        CreatorId = storeItem.Description?.CreatorId,
+                        CreatorName = storeItem.Description?.CreatorProfile?.Name,
+                        CreatorAvatarUrl = storeItem.Description?.CreatorProfile?.AvatarUrl,
+                        ItemId = UInt64.Parse(storeItem.SteamId),
+                        ItemType = storeItem.Description?.ItemType,
+                        ItemShortName = storeItem.Description?.ItemShortName,
+                        ItemName = storeItem.Description?.Name,
+                        ItemDescription = storeItem.Description?.Description,
+                        ItemCollection = storeItem.Description?.ItemCollection,
+                        ItemIconUrl = storeItem.Description?.IconUrl ?? storeItem.Description?.IconLargeUrl,
+                        ItemImageUrl = storeItem.Description?.PreviewUrl ?? storeItem.Description?.IconLargeUrl ?? storeItem.Description?.IconUrl,
+                        ItemPrices = storeItem.Prices.Select(x => new StoreItemAddedMessage.Price()
+                        {
+                            Currency = x.Key,
+                            Value = x.Value,
+                            Description = usdCurrency?.ToPriceString(x.Value)
+                        }).ToArray()
+                    });
+                }
+            }
+        }
+    }
+}

--- a/SCMM.Web.Client/Pages/IndexPage.razor
+++ b/SCMM.Web.Client/Pages/IndexPage.razor
@@ -9,7 +9,7 @@
         base.OnAfterRender(firstRender);
         if (firstRender)
         {
-            if (State?.App?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreBrowser) == true)
+            if (State?.App?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStore) == true)
             {
                 NavigationManager.NavigateTo("/store");
             }

--- a/SCMM.Web.Client/Shared/Layout/AppNavigationMenu.razor
+++ b/SCMM.Web.Client/Shared/Layout/AppNavigationMenu.razor
@@ -27,7 +27,7 @@
         <span class="no-wrap">Items</span>
     </MudNavLink>
 
-    @if (State.App?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreBrowser) == true)
+    @if (State.App?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStore) == true)
     {
         <MudNavLink Href="/store" Icon="fas fa-fw fa-shopping-cart" Disabled="@State.IsPrerendering">
             <span class="no-wrap">Item Stores</span>

--- a/SCMM.Web.Server/API/Controllers/StoreController.cs
+++ b/SCMM.Web.Server/API/Controllers/StoreController.cs
@@ -51,23 +51,31 @@ namespace SCMM.Web.Server.API.Controllers
         public async Task<IActionResult> GetStores()
         {
             var app = this.App();
-            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePersistent) != true && app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
+            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStore) != true)
             {
                 return BadRequest("App does not support stores");
             }
 
-            var itemStores = await _db.SteamItemStores
-                .AsNoTracking()
-                .Where(x => x.AppId == app.Guid)
-                .OrderByDescending(x => x.Start == null)
-                .ThenByDescending(x => x.Start)
-                .ToListAsync();
+            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) == true)
+            {
+                var itemStores = await _db.SteamItemStores
+                    .AsNoTracking()
+                    .Where(x => x.AppId == app.Guid)
+                    .OrderByDescending(x => x.Start == null)
+                    .ThenByDescending(x => x.Start)
+                    .ToListAsync();
 
-            return Ok(
-                itemStores
-                    .Select(x => _mapper.Map<SteamItemStore, StoreIdentifierDTO>(x, this))
-                    .ToArray()
-            );
+                return Ok(
+                    itemStores
+                        .Select(x => _mapper.Map<SteamItemStore, StoreIdentifierDTO>(x, this))
+                        .ToArray()
+                );
+            }
+            else
+            {
+                return Ok(new StoreIdentifierDTO[0]);
+            }
+
         }
 
         /// <summary>
@@ -115,7 +123,7 @@ namespace SCMM.Web.Server.API.Controllers
         public async Task<IActionResult> GetStore([FromRoute] string id)
         {
             var app = this.App();
-            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePersistent) != true && app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
+            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStore) != true)
             {
                 return BadRequest("App does not support stores");
             }
@@ -236,9 +244,9 @@ namespace SCMM.Web.Server.API.Controllers
         public async Task<IActionResult> GetStoreItemSalesStats([FromRoute] Guid id)
         {
             var app = this.App();
-            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePersistent) != true && app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
+            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
             {
-                return BadRequest("App does not support stores");
+                return BadRequest("App does not support store sale statistics");
             }
 
             if (Guid.Empty == id)
@@ -308,9 +316,9 @@ namespace SCMM.Web.Server.API.Controllers
         public async Task<IActionResult> GetStoreItemRevenueStats([FromRoute] Guid id)
         {
             var app = this.App();
-            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePersistent) != true && app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
+            if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
             {
-                return BadRequest("App does not support stores");
+                return BadRequest("App does not support store revenue statistics");
             }
 
             if (Guid.Empty == id)
@@ -392,7 +400,7 @@ namespace SCMM.Web.Server.API.Controllers
             var app = this.App();
             if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePersistent) != true && app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
             {
-                return BadRequest("App does not support stores");
+                return BadRequest("App does not support store item linking");
             }
 
             if (Guid.Empty == id)
@@ -521,7 +529,7 @@ namespace SCMM.Web.Server.API.Controllers
             var app = this.App();
             if (app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStorePersistent) != true && app?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemStoreRotating) != true)
             {
-                return BadRequest("App does not support stores");
+                return BadRequest("App does not support store item unlinking");
             }
 
             if (Guid.Empty == id)


### PR DESCRIPTION
## Changes
- Add job to import store items
- Only raise "buy deal detected" events if the current best buy deal is better than the last best deal
- Better support for viewing app stores that don't follow the normal persistent or rotating format
