### PR TITLE
Fix market item prices not updating

### DIFF
--- a/SCMM.Steam.Data.Store/SteamMarketItem.cs
+++ b/SCMM.Steam.Data.Store/SteamMarketItem.cs
@@ -245,6 +245,7 @@ namespace SCMM.Steam.Data.Store
             // What was the best buy price prior to this price update?
             var lastBestBuyPrice = BuyPrices
                 .Where(x => x.Value.Price > 0 && x.Value.Supply != 0)
+                .DefaultIfEmpty()
                 .Min(x => x.Value.Price);
 
             if (price?.Price > 0 && (price?.Supply == null || price?.Supply > 0))
@@ -282,6 +283,7 @@ namespace SCMM.Steam.Data.Store
                     })
                     .MinBy(x => x.Price + x.Fee);
                 var buyNowDealHasImproved = (
+                    lowestBuyPrice.Price > 0 && lastBestBuyPrice > 0 &&
                     lowestBuyPrice.Price < lastBestBuyPrice &&
                     lowestBuyPrice.Price.ToPercentage(lastBestBuyPrice) < 100
                 );

--- a/SCMM.Steam.Functions/Timer/CheckForNewStoreItems.cs
+++ b/SCMM.Steam.Functions/Timer/CheckForNewStoreItems.cs
@@ -34,7 +34,7 @@ public class CheckForNewStoreItems
     }
 
     [Function("Check-New-Store-Items")]
-    public async Task Run([TimerTrigger("0 * * * * *")] /* every minute */ TimerInfo timerInfo, FunctionContext context)
+    public async Task Run([TimerTrigger("0 0/2 * * * *")] /* every 2 minutes */ TimerInfo timerInfo, FunctionContext context)
     {
         var logger = context.GetLogger("Check-New-Store-Items");
 


### PR DESCRIPTION
## Changes
- Fix "sequence contains no elements" error when updating market item prices
- Reduce "check for new store items" job frequency from every 1 minute to ever 2 minutes