### PR TITLE
Change "estimated sales" to "minimum sales" for better clarity

### DIFF
--- a/SCMM.Shared.Data.Models/Extensions/NumberExtensions.cs
+++ b/SCMM.Shared.Data.Models/Extensions/NumberExtensions.cs
@@ -129,6 +129,11 @@
             return b == 0 ? Math.Abs(a) : GCD(b, a % b);
         }
 
+        public static long RoundDownToNearest(this long value, long roundTo)
+        {
+            return (long)(Math.Floor((double)value / roundTo) * roundTo);
+        }
+
         public static IEnumerable<decimal> CumulativeMovingAverage(this IEnumerable<decimal> source)
         {
             ulong count = 0;

--- a/SCMM.Web.Client/Pages/Inventory/InventoryPage.razor
+++ b/SCMM.Web.Client/Pages/Inventory/InventoryPage.razor
@@ -103,8 +103,8 @@
                                     }
                                     @if (State.Profile.ItemInfo.Any(x => x == ItemInfoType.EstimatedTotalSupply))
                                     {
-                                        <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ProfileInventoryItemDescriptionDTO.SupplyTotalEstimated), Data.Models.SortDirection.Ascending))">Lowest Estimated Total Supply</MudMenuItem>
-                                        <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ProfileInventoryItemDescriptionDTO.SupplyTotalEstimated), Data.Models.SortDirection.Descending))">Highest Estimated Total Supply</MudMenuItem>
+                                        <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ProfileInventoryItemDescriptionDTO.SupplyTotalEstimated), Data.Models.SortDirection.Ascending))">Lowest Minimum Total Supply</MudMenuItem>
+                                        <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ProfileInventoryItemDescriptionDTO.SupplyTotalEstimated), Data.Models.SortDirection.Descending))">Highest Minimum Total Supply</MudMenuItem>
                                     }
                                     <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ProfileInventoryItemDescriptionDTO.DistanceToAllTimeHighestValue), Data.Models.SortDirection.Descending))">Closest to All Time High (ATH)</MudMenuItem>
                                     <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ProfileInventoryItemDescriptionDTO.DistanceToAllTimeLowestValue), Data.Models.SortDirection.Ascending))">Closest to All Time Low (ATL)</MudMenuItem>

--- a/SCMM.Web.Client/Pages/Items/ItemsPage.razor
+++ b/SCMM.Web.Client/Pages/Items/ItemsPage.razor
@@ -79,8 +79,8 @@
                 }
                 @if (State.Profile.ItemInfo.Any(x => x == ItemInfoType.EstimatedTotalSupply))
                 {
-                    <MudSelectItem Value="@(new Tuple<string, Data.Models.SortDirection>("SupplyTotalEstimated", Data.Models.SortDirection.Ascending))">Lowest Estimated Total Supply</MudSelectItem>
-                    <MudSelectItem Value="@(new Tuple<string, Data.Models.SortDirection>("SupplyTotalEstimated", Data.Models.SortDirection.Descending))">Highest Estimated Total Supply</MudSelectItem>
+                    <MudSelectItem Value="@(new Tuple<string, Data.Models.SortDirection>("SupplyTotalEstimated", Data.Models.SortDirection.Ascending))">Lowest Minimum Total Supply</MudSelectItem>
+                    <MudSelectItem Value="@(new Tuple<string, Data.Models.SortDirection>("SupplyTotalEstimated", Data.Models.SortDirection.Descending))">Highest Minimum Total Supply</MudSelectItem>
                 }
                 <MudSelectItem Value="@(new Tuple<string, Data.Models.SortDirection>("DistanceToAllTimeHighestValue", Data.Models.SortDirection.Descending))">Closest to All Time High (ATH)</MudSelectItem>
                 <MudSelectItem Value="@(new Tuple<string, Data.Models.SortDirection>("DistanceToAllTimeLowestValue", Data.Models.SortDirection.Ascending))">Closest to All Time Low (ATL)</MudSelectItem>

--- a/SCMM.Web.Client/Pages/Statistics/StatisticsItemPanel.razor
+++ b/SCMM.Web.Client/Pages/Statistics/StatisticsItemPanel.razor
@@ -114,7 +114,7 @@
                                     </td>
                                     <td class="text-right">
                                         <MudText Typo="Typo.body2" Class="no-wrap">
-                                            <span>@item.SupplyTotalEstimated.ToQuantityString()+ minimum supply</span>
+                                            <span>@item.SupplyTotalEstimated.ToQuantityString() minimum supply</span>
                                         </MudText>
                                     </td>
                                 </tr>

--- a/SCMM.Web.Client/Pages/Statistics/StatisticsItemPanel.razor
+++ b/SCMM.Web.Client/Pages/Statistics/StatisticsItemPanel.razor
@@ -114,7 +114,7 @@
                                     </td>
                                     <td class="text-right">
                                         <MudText Typo="Typo.body2" Class="no-wrap">
-                                            <span>@item.SupplyTotalEstimated.ToQuantityString()+ estimated supply</span>
+                                            <span>@item.SupplyTotalEstimated.ToQuantityString()+ minimum supply</span>
                                         </MudText>
                                     </td>
                                 </tr>

--- a/SCMM.Web.Client/Pages/Statistics/StatisticsItemPanel.razor
+++ b/SCMM.Web.Client/Pages/Statistics/StatisticsItemPanel.razor
@@ -94,7 +94,7 @@
     @if (State.App?.FeatureFlags.HasFlag(SteamAppFeatureFlags.ItemWorkshop) == true)
     {
         <MudItem xs="12" md="6" xl="3">
-            <StatisticsPanel Icon="fas fa-fw fa-cubes-stacked mr-1" Title="Highest Estimated Item Supply" Subtitle="Which items have the highest estimated total supply?" Dense="true">
+            <StatisticsPanel Icon="fas fa-fw fa-cubes-stacked mr-1" Title="Highest Minimum Item Supply" Subtitle="Which items have the highest minimum total supply?" Dense="true">
                 <MudSimpleTable Dense="true" Hover="true" FixedHeader="true" Style="height:30vh;" Class="flex-grow-1">
                     <tbody>
                         <Virtualize ItemsProvider="LoadItemMostSupply" Context="item" SpacerElement="tr" OverscanCount="5">

--- a/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
+++ b/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
@@ -29,11 +29,11 @@
                 {
                     <small class="px-2">
                         <i class="fa fa-fw fa-shopping-cart mr-1" />
-                        <span>@Store.Items.Sum(x => x.SupplyTotalEstimated ?? 0).ToQuantityString()+ <span class="mud-secondary-text">estimated sales</span></span>
+                        <span>@Store.Items.Sum(x => x.SupplyTotalEstimated ?? 0).ToQuantityString()+ <span class="mud-secondary-text">minimum sales</span></span>
                     </small>
                     <small class="px-2">
                         <i class="fa fa-fw fa-hand-holding-usd mr-1" />
-                        <span>@State.Currency.ToPriceString(State.Currency.CalculateExchange(Store.Items.Sum(x => (x.SupplyTotalEstimated ?? 0) * (x.StorePriceUsd ?? 0))))+ <span class="mud-secondary-text">estimated revenue</span></span>
+                        <span>@State.Currency.ToPriceString(State.Currency.CalculateExchange(Store.Items.Sum(x => (x.SupplyTotalEstimated ?? 0) * (x.StorePriceUsd ?? 0))))+ <span class="mud-secondary-text">minimum revenue</span></span>
                     </small>
                 }
             </MudText>
@@ -102,7 +102,7 @@
                             }
                         </MudTabPanel>
                     }
-                    <MudTabPanel Icon="fas fa-fw fa-shopping-cart mr-2" Text="Estimated Sales" Disabled="@(Store?.Items?.Any(x => x.SupplyTotalEstimated > 0) != true)">
+                    <MudTabPanel Icon="fas fa-fw fa-shopping-cart mr-2" Text="Minimum Sales" Disabled="@(Store?.Items?.Any(x => x.SupplyTotalEstimated > 0) != true)">
                         @if ((Store?.Items?.Any(x => x.SupplyTotalEstimated > 0) != true))
                         {
                             <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="pa-8 text-centered">
@@ -158,7 +158,7 @@
                             </SfChart>
                         }
                     </MudTabPanel>
-                    <MudTabPanel Icon="fas fa-fw fa-hand-holding-usd mr-2" Text="Estimated Revenue" Disabled="@(Store?.Items?.Any(x => x.SupplyTotalEstimated > 0) != true)">
+                    <MudTabPanel Icon="fas fa-fw fa-hand-holding-usd mr-2" Text="Minimum Revenue" Disabled="@(Store?.Items?.Any(x => x.SupplyTotalEstimated > 0) != true)">
                         @if ((Store?.Items?.Any(x => x.SupplyTotalEstimated > 0) != true))
                         {
                             <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="pa-8 text-centered">

--- a/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
+++ b/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
@@ -29,11 +29,11 @@
                 {
                     <small class="px-2">
                         <i class="fa fa-fw fa-shopping-cart mr-1" />
-                        <span>@Store.Items.Sum(x => x.SupplyTotalEstimated ?? 0).ToQuantityString()+ <span class="mud-secondary-text">minimum sales</span></span>
+                        <span>@Store.Items.Sum(x => x.SupplyTotalEstimated ?? 0).ToQuantityString() <span class="mud-secondary-text">minimum sales</span></span>
                     </small>
                     <small class="px-2">
                         <i class="fa fa-fw fa-hand-holding-usd mr-1" />
-                        <span>@State.Currency.ToPriceString(State.Currency.CalculateExchange(Store.Items.Sum(x => (x.SupplyTotalEstimated ?? 0) * (x.StorePriceUsd ?? 0))))+ <span class="mud-secondary-text">minimum revenue</span></span>
+                        <span>@State.Currency.ToPriceString(State.Currency.CalculateExchange(Store.Items.Sum(x => (x.SupplyTotalEstimated ?? 0) * (x.StorePriceUsd ?? 0)))) <span class="mud-secondary-text">minimum revenue</span></span>
                     </small>
                 }
             </MudText>
@@ -181,7 +181,7 @@
                                 </ChartArea>
                                 <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category" EdgeLabelPlacement="EdgeLabelPlacement.Shift">
                                 </ChartPrimaryXAxis>
-                                <ChartPrimaryYAxis LabelFormat="@($"{State.Currency.PrefixText}#,##0.00{State.Currency.SuffixText}+")" EdgeLabelPlacement="EdgeLabelPlacement.Shift">
+                                <ChartPrimaryYAxis LabelFormat="@($"{State.Currency.PrefixText}#,##0.00{State.Currency.SuffixText} (minimum)")" EdgeLabelPlacement="EdgeLabelPlacement.Shift">
                                     <ChartAxisLineStyle Width="0"></ChartAxisLineStyle>
                                     <ChartAxisLabelStyle Color="transparent"></ChartAxisLabelStyle>
                                     <ChartAxisMajorTickLines Width="0"></ChartAxisMajorTickLines>

--- a/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
+++ b/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
@@ -133,19 +133,19 @@
                                     <ChartSeries XName="name" YName="supplyTotalMarketsKnown" Name="Currently listed on the market" StackingGroup="Breakdown" ColumnWidth="0.5" Fill="#171a21" Width="2" Type="ChartSeriesType.StackingBar">
                                         <ChartEmptyPointSettings Mode="EmptyPointMode.Drop" />
                                     </ChartSeries>
-                                    <ChartSeries XName="name" YName="supplyTotalOwnersKnown" Name="User currently hold this item" StackingGroup="Breakdown" ColumnWidth="0.5" Width="2" Fill="#1565c0" Type="ChartSeriesType.StackingBar">
+                                    <ChartSeries XName="name" YName="supplyTotalOwnersKnown" Name="Tracked subscribers currently holding this item" StackingGroup="Breakdown" ColumnWidth="0.5" Width="2" Fill="#1565c0" Type="ChartSeriesType.StackingBar">
                                         <ChartEmptyPointSettings Mode="EmptyPointMode.Drop" />
                                     </ChartSeries>
-                                    <ChartSeries XName="name" YName="supplyTotalOwnersEstimated" Name="Unknown subscribers to this item" StackingGroup="Breakdown" ColumnWidth="0.5" Width="2" Fill="#1e88e5" Type="ChartSeriesType.StackingBar">
+                                    <ChartSeries XName="name" YName="supplyTotalOwnersEstimated" Name="Untracked workshop subscribers of this item" StackingGroup="Breakdown" ColumnWidth="0.5" Width="2" Fill="#1e88e5" Type="ChartSeriesType.StackingBar">
                                         <ChartEmptyPointSettings Mode="EmptyPointMode.Drop" />
                                     </ChartSeries>
-                                    <ChartSeries XName="name" YName="supplyTotalInvestorsKnown" Name="Duplicate inventory stock held of this item " StackingGroup="Breakdown" ColumnWidth="0.5" Fill="#6a1b9a" Width="2" Type="ChartSeriesType.StackingBar">
+                                    <ChartSeries XName="name" YName="supplyTotalInvestorsKnown" Name="Tracked duplicate inventory stock held of this item" StackingGroup="Breakdown" ColumnWidth="0.5" Fill="#6a1b9a" Width="2" Type="ChartSeriesType.StackingBar">
                                         <ChartEmptyPointSettings Mode="EmptyPointMode.Drop" />
                                     </ChartSeries>
-                                    <ChartSeries XName="name" YName="supplyTotalInvestorsEstimated" Name="Possible duplicate inventory stock held of this item" StackingGroup="Breakdown" ColumnWidth="0.5" Fill="#8e24aa" Width="2" Type="ChartSeriesType.StackingBar">
+                                    <ChartSeries XName="name" YName="supplyTotalInvestorsEstimated" Name="Untracked estimated duplicate inventory stock held of this item" StackingGroup="Breakdown" ColumnWidth="0.5" Fill="#8e24aa" Width="2" Type="ChartSeriesType.StackingBar">
                                         <ChartEmptyPointSettings Mode="EmptyPointMode.Drop" />
                                     </ChartSeries>
-                                    <ChartSeries XName="name" YName="supplyTotalEstimated" Name="Total estimated sales" StackingGroup="Total" ColumnWidth="1" Fill="#388e3c" Width="2" Type="ChartSeriesType.Bar">
+                                    <ChartSeries XName="name" YName="supplyTotalEstimated" Name="Total minimum sales" StackingGroup="Total" ColumnWidth="1" Fill="#388e3c" Width="2" Type="ChartSeriesType.Bar">
                                         <ChartMarker>
                                             <ChartDataLabel Visible="true" Name="totalText" Position="Syncfusion.Blazor.Charts.LabelPosition.Top">
                                                 <ChartDataLabelFont FontWeight="600" Color="#eeeeee"></ChartDataLabelFont>
@@ -200,7 +200,7 @@
                                     <ChartSeries XName="name" YName="publisherRevenue" Name="@($"{State.App.PublisherName} revenue")" StackingGroup="Breakdown" ColumnWidth="0.5" Width="2" Fill="@State.App?.PrimaryColor" Type="ChartSeriesType.StackingBar">
                                         <ChartEmptyPointSettings Mode="EmptyPointMode.Drop" />
                                     </ChartSeries>
-                                    <ChartSeries XName="name" YName="total" Name="Total estimated revenue" StackingGroup="Total" ColumnWidth="1" Fill="#388e3c" Width="2" Type="ChartSeriesType.Bar">
+                                    <ChartSeries XName="name" YName="total" Name="Total minimum revenue" StackingGroup="Total" ColumnWidth="1" Fill="#388e3c" Width="2" Type="ChartSeriesType.Bar">
                                         <ChartMarker>
                                             <ChartDataLabel Visible="true" Position="Syncfusion.Blazor.Charts.LabelPosition.Top">
                                                 <ChartDataLabelFont FontWeight="600" Color="#eeeeee"></ChartDataLabelFont>

--- a/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
+++ b/SCMM.Web.Client/Pages/Store/StoreAnalyticsPanel.razor
@@ -29,11 +29,11 @@
                 {
                     <small class="px-2">
                         <i class="fa fa-fw fa-shopping-cart mr-1" />
-                        <span>@Store.Items.Sum(x => x.SupplyTotalEstimated ?? 0).ToQuantityString() <span class="mud-secondary-text">minimum sales</span></span>
+                        <span>@Store.Items.Sum(x => x.SupplyTotalEstimated ?? 0).RoundDownToNearest(1000).ToQuantityString() <span class="mud-secondary-text">minimum sales</span></span>
                     </small>
                     <small class="px-2">
                         <i class="fa fa-fw fa-hand-holding-usd mr-1" />
-                        <span>@State.Currency.ToPriceString(State.Currency.CalculateExchange(Store.Items.Sum(x => (x.SupplyTotalEstimated ?? 0) * (x.StorePriceUsd ?? 0)))) <span class="mud-secondary-text">minimum revenue</span></span>
+                        <span>@State.Currency.ToPriceString(State.Currency.CalculateExchange(Store.Items.Sum(x => (x.SupplyTotalEstimated ?? 0) * (x.StorePriceUsd ?? 0))).RoundDownToNearest(100000)) <span class="mud-secondary-text">minimum revenue</span></span>
                     </small>
                 }
             </MudText>

--- a/SCMM.Web.Client/Pages/Store/StorePage.razor
+++ b/SCMM.Web.Client/Pages/Store/StorePage.razor
@@ -237,7 +237,7 @@ else if (StoreList.Any())
                                                 <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Class="no-wrap" GutterBottom>
                                                     <i class="fas fa-fw fa-shopping-cart mud-secondary-text"></i>
                                                     <span>
-                                                        <MudLink @onclick="@(() => ShowItemEstimatedSupplyDialog(item))" Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Disabled="State.IsPrerendering">@item.SupplyTotalEstimated.Value.ToQuantityString()+ estimated sales</MudLink>
+                                                        <MudLink @onclick="@(() => ShowItemEstimatedSupplyDialog(item))" Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Disabled="State.IsPrerendering">@item.SupplyTotalEstimated.Value.ToQuantityString()+ minimum sales</MudLink>
                                                         <span class="mud-secondary-text"> from the store</span>
                                                     </span>
                                                 </MudText>

--- a/SCMM.Web.Client/Pages/Store/StorePage.razor
+++ b/SCMM.Web.Client/Pages/Store/StorePage.razor
@@ -237,7 +237,7 @@ else if (StoreList.Any())
                                                 <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Class="no-wrap" GutterBottom>
                                                     <i class="fas fa-fw fa-shopping-cart mud-secondary-text"></i>
                                                     <span>
-                                                        <MudLink @onclick="@(() => ShowItemEstimatedSupplyDialog(item))" Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Disabled="State.IsPrerendering">@item.SupplyTotalEstimated.Value.ToQuantityString()+ minimum sales</MudLink>
+                                                        <MudLink @onclick="@(() => ShowItemEstimatedSupplyDialog(item))" Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Disabled="State.IsPrerendering">@item.SupplyTotalEstimated.Value.ToQuantityString() minimum sales</MudLink>
                                                         <span class="mud-secondary-text"> from the store</span>
                                                     </span>
                                                 </MudText>

--- a/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
+++ b/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
@@ -241,7 +241,7 @@
                             <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Class="no-wrap" GutterBottom>
                                 <i class="fas fa-fw fa-cubes-stacked mud-secondary-text"></i>
                                 <span>
-                                    <span>@Item.SupplyTotalEstimated.Value.ToQuantityString()+ <span class="mud-secondary-text">estimated total</span> supply</span>
+                                    <span>@Item.SupplyTotalEstimated.Value.ToQuantityString()+ <span class="mud-secondary-text">minimum</span> supply</span>
                                 </span>
                             </MudText>
                         }
@@ -744,7 +744,7 @@
                 <MudItem xs="12" xl="@((Item.IsAvailableOnMarket || Item.MarketLastSaleOn != null || Item.MarketSellOrderCount > 0 || Item.MarketBuyOrderCount > 0) ? 6 : 12)">
                     <MudPaper Outlined="true" Class="text-centered full-height" Style="min-height:20vh">
                         <MudText Typo="MudBlazor.Typo.h6" Color="MudBlazor.Color.Default" Class="pa-2 text-centered">
-                            <span>@Item.SupplyTotalEstimated.Value.ToQuantityString()+ estimated total supply</span>
+                            <span>@Item.SupplyTotalEstimated.Value.ToQuantityString()+ minimum supply</span>
                         </MudText>
                         <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="px-4 text-centered">
                             @if (((Item.SupplyTotalOwnersEstimated ?? 0) + (Item.SupplyTotalInvestorsEstimated ?? 0)) > ((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)))

--- a/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
+++ b/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
@@ -1281,7 +1281,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"Unknown subscribers to this item ({outstandingEstimatedUniqueOwnerSupply.ToQuantityString()})",
+                Name = $"Untracked workshop subscribers of this item ({outstandingEstimatedUniqueOwnerSupply.ToQuantityString()})",
                 Value = (double) outstandingEstimatedUniqueOwnerSupply
             });
         }
@@ -1289,7 +1289,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"User currently hold this item ({Item.SupplyTotalOwnersKnown.Value.ToQuantityString()})",
+                Name = $"Tracked subscribers currently holding this item ({Item.SupplyTotalOwnersKnown.Value.ToQuantityString()})",
                 Value = (double) Item.SupplyTotalOwnersKnown.Value
             });
         }
@@ -1299,7 +1299,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"Possible duplicate inventory stock held of this item ({outstandingEstimatedInvestorsSupply.ToQuantityString()})",
+                Name = $"Untracked estimated duplicate inventory stock held of this item ({outstandingEstimatedInvestorsSupply.ToQuantityString()})",
                 Value = (double) outstandingEstimatedInvestorsSupply
             });
         }
@@ -1307,7 +1307,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"Duplicate inventory stock held of this item ({Item.SupplyTotalInvestorsKnown.Value.ToQuantityString()})",
+                Name = $"Tracked duplicate inventory stock held of this item ({Item.SupplyTotalInvestorsKnown.Value.ToQuantityString()})",
                 Value = (double) Item.SupplyTotalInvestorsKnown.Value
             });
         }

--- a/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
+++ b/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
@@ -749,11 +749,11 @@
                         <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="px-4 text-centered">
                             @if (((Item.SupplyTotalOwnersEstimated ?? 0) + (Item.SupplyTotalInvestorsEstimated ?? 0)) > ((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)))
                             {
-                                <span>We estimate there are at least <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, of which <strong>@(((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)).ToQuantityString())</strong> are currently known and tracked by SCMM.</span>
+                                <span>We estimate there are no less than <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, of which <strong>@(((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)).ToQuantityString())</strong> are currently known and tracked by SCMM.</span>
                             }
                             else
                             {
-                                <span>We known that there are at least <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, through supply channels known and tracked by SCMM.</span>
+                                <span>We've detected at least <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, through inventories known and tracked by SCMM.</span>
                             }
                             <span> Our database is not comprehensive and there are always more copies that we don't know about. </span>
                         </MudText>

--- a/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
+++ b/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionDetails.razor
@@ -241,7 +241,7 @@
                             <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Default" Class="no-wrap" GutterBottom>
                                 <i class="fas fa-fw fa-cubes-stacked mud-secondary-text"></i>
                                 <span>
-                                    <span>@Item.SupplyTotalEstimated.Value.ToQuantityString()+ <span class="mud-secondary-text">minimum</span> supply</span>
+                                    <span>@Item.SupplyTotalEstimated.Value.ToQuantityString() <span class="mud-secondary-text">minimum</span> supply</span>
                                 </span>
                             </MudText>
                         }
@@ -744,7 +744,7 @@
                 <MudItem xs="12" xl="@((Item.IsAvailableOnMarket || Item.MarketLastSaleOn != null || Item.MarketSellOrderCount > 0 || Item.MarketBuyOrderCount > 0) ? 6 : 12)">
                     <MudPaper Outlined="true" Class="text-centered full-height" Style="min-height:20vh">
                         <MudText Typo="MudBlazor.Typo.h6" Color="MudBlazor.Color.Default" Class="pa-2 text-centered">
-                            <span>@Item.SupplyTotalEstimated.Value.ToQuantityString()+ minimum supply</span>
+                            <span>@Item.SupplyTotalEstimated.Value.ToQuantityString() minimum supply</span>
                         </MudText>
                         <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="px-4 text-centered">
                             @if (((Item.SupplyTotalOwnersEstimated ?? 0) + (Item.SupplyTotalInvestorsEstimated ?? 0)) > ((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)))

--- a/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionSummary.razor
+++ b/SCMM.Web.Client/Shared/Components/Items/ItemDescriptionSummary.razor
@@ -48,7 +48,7 @@
                 {
                     @if (OwnableItem?.SupplyTotalEstimated > 0 && (State.Profile.ItemInfo == null || State.Profile.ItemInfo.Any(x => x == ItemInfoType.EstimatedTotalSupply)))
                     {
-                        <MudTooltip Text="Estimated total supply">
+                        <MudTooltip Text="Minimum supply">
                             <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="no-wrap">
                                 <i class="fas fa-fw fa-cubes-stacked"></i>
                                 <span>@OwnableItem.SupplyTotalEstimated.Value.ToQuantityString()+</span>

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemCollectionDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemCollectionDialog.razor
@@ -60,8 +60,8 @@
                         }
                         @if (State.Profile.ItemInfo.Any(x => x == ItemInfoType.EstimatedTotalSupply))
                         {
-                            <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Ascending))">Lowest Estimated Total Supply</MudMenuItem>
-                            <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Descending))">Highest Estimated Total Supply</MudMenuItem>
+                            <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Ascending))">Lowest Minimum Supply</MudMenuItem>
+                            <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Descending))">Highest Minimum Supply</MudMenuItem>
                         }
                     </ChildContent>
                 </MudMenu>

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemEstimatedSupplyDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemEstimatedSupplyDialog.razor
@@ -11,7 +11,7 @@
 
 <MudDialog>
     <TitleContent>
-        <MudText Typo="MudBlazor.Typo.h6">@ItemName Estimated Supply</MudText>
+        <MudText Typo="MudBlazor.Typo.h6">@ItemName Minimum Supply</MudText>
     </TitleContent>
     <DialogContent>
         @if (Item == null)

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemEstimatedSupplyDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemEstimatedSupplyDialog.razor
@@ -145,7 +145,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"Unknown subscribers to this item ({outstandingEstimatedUniqueOwnerSupply.ToQuantityString()})",
+                Name = $"Untracked workshop subscribers of this item ({outstandingEstimatedUniqueOwnerSupply.ToQuantityString()})",
                 Value = (double) outstandingEstimatedUniqueOwnerSupply
             });
         }
@@ -153,7 +153,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"User currently hold this item ({Item.SupplyTotalOwnersKnown.Value.ToQuantityString()})",
+                Name = $"Tracked subscribers currently holding this item ({Item.SupplyTotalOwnersKnown.Value.ToQuantityString()})",
                 Value = (double) Item.SupplyTotalOwnersKnown.Value
             });
         }
@@ -163,7 +163,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"Possible duplicate inventory stock held of this item ({outstandingEstimatedInvestorsSupply.ToQuantityString()})",
+                Name = $"Untracked estimated duplicate inventory stock held of this item ({outstandingEstimatedInvestorsSupply.ToQuantityString()})",
                 Value = (double) outstandingEstimatedInvestorsSupply
             });
         }
@@ -171,7 +171,7 @@
         {
             itemSupplyDistribution.Add(new ChartData() 
             {
-                Name = $"Duplicate inventory stock held of this item ({Item.SupplyTotalInvestorsKnown.Value.ToQuantityString()})",
+                Name = $"Tracked duplicate inventory stock held of this item ({Item.SupplyTotalInvestorsKnown.Value.ToQuantityString()})",
                 Value = (double) Item.SupplyTotalInvestorsKnown.Value
             });
         }

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemEstimatedSupplyDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemEstimatedSupplyDialog.razor
@@ -31,11 +31,11 @@
                         <MudText Typo="MudBlazor.Typo.body2" Color="MudBlazor.Color.Secondary" Class="px-4 text-centered">
                             @if (((Item.SupplyTotalOwnersEstimated ?? 0) + (Item.SupplyTotalInvestorsEstimated ?? 0)) > ((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)))
                             {
-                                <span>We estimate there are at least <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, of which <strong>@(((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)).ToQuantityString())</strong> are currently known and tracked by SCMM.</span>
+                                <span>We estimate there are no less than <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, of which <strong>@(((Item.SupplyTotalOwnersKnown ?? 0) + (Item.SupplyTotalInvestorsKnown ?? 0) + (Item.SupplyTotalMarketsKnown ?? 0)).ToQuantityString())</strong> are currently known and tracked by SCMM.</span>
                             }
                             else
                             {
-                                <span>We known that there are at least <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, through supply channels known and tracked by SCMM.</span>
+                                <span>We've detected at least <strong>@Item.SupplyTotalEstimated.Value.ToQuantityString()</strong> copies of this item in circulation, through inventories known and tracked by SCMM.</span>
                             }
                             <span> Our database is not comprehensive and there are always more copies that we don't know about. </span>
                         </MudText>

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemListDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemListDialog.razor
@@ -45,8 +45,8 @@
                             }
                             @if (State.Profile.ItemInfo.Any(x => x == ItemInfoType.EstimatedTotalSupply))
                             {
-                                <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Ascending))">Lowest Estimated Total Supply</MudMenuItem>
-                                <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Descending))">Highest Estimated Total Supply</MudMenuItem>
+                                <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Ascending))">Lowest Minimum Supply</MudMenuItem>
+                                <MudMenuItem OnClick="@(() => SetSortOrder(nameof(ItemDescriptionWithPriceDTO.SupplyTotalEstimated), Data.Models.SortDirection.Descending))">Highest Minimum Supply</MudMenuItem>
                             }
                         </ChildContent>
                     </MudMenu>


### PR DESCRIPTION
- Change "estimated sales" to "minimum sales" for better clarity
- Round down aggregated store sales totals for better clarity
- Use clearer wording when describing minimum supply estimates

closes #31