### PR TITLE
App bar action pinning

### DIFF
--- a/SCMM.Web.Client/Program.cs
+++ b/SCMM.Web.Client/Program.cs
@@ -1,3 +1,4 @@
+using Blazored.LocalStorage;
 using Ljbc1994.Blazor.IntersectionObserver;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -75,11 +76,14 @@ public static class WebAssemblyHostExtensions
         services.AddScoped<AppState>();
 
         services.AddScoped<ExternalNavigationManager>();
+        services.AddScoped<PinnedActionManager>();
         services.AddScoped<DocumentManager>();
 
         services.AddTransient<VirtualisedItemsMemoryCache>();
 
         services.AddIntersectionObserver();
+
+        services.AddBlazoredLocalStorage();
 
         services.AddMudServices(config =>
         {

--- a/SCMM.Web.Client/SCMM.Web.Client.csproj
+++ b/SCMM.Web.Client/SCMM.Web.Client.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="BlazorIntersectionObserver" Version="3.1.0" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" />

--- a/SCMM.Web.Client/Shared/Components/SearchBar.razor
+++ b/SCMM.Web.Client/Shared/Components/SearchBar.razor
@@ -96,6 +96,16 @@
         Search = null;
         switch (type)
         {
+            case "List":
+                Dialogs.Show<ViewItemListDialog>(null, parameters: new DialogParameters()
+                {
+                    ["ListName"] = description,
+                    ["ListUrl"] = url,
+                    ["SortBy"] = nameof(ItemDescriptionWithPriceDTO.TimeAccepted),
+                    ["SortDirection"] = MudBlazor.SortDirection.Descending
+                });
+                break;
+
             case "Type":
                 Dialogs.Show<ViewItemListDialog>(null, parameters: new DialogParameters()
                 {

--- a/SCMM.Web.Client/Shared/Components/SearchBar.razor
+++ b/SCMM.Web.Client/Shared/Components/SearchBar.razor
@@ -1,35 +1,75 @@
-﻿@using SCMM.Web.Client.Shared.Dialogs.Items
+﻿@inherits PersistentComponent
+@using SCMM.Web.Client.Shared.Dialogs.Items
 @using SCMM.Web.Data.Models.UI.Item
 @using SCMM.Web.Data.Models.UI.Search
 @inject ILogger<SearchBar> Logger
 @inject IDialogService Dialogs
 @inject NavigationManager NavigationManager
 @inject ExternalNavigationManager ExternalNavigationManager
+@inject PinnedActionManager PinnedActionManager
 @inject AppState State
 @inject HttpClient Http
 
-<MudAutocomplete T="SearchResultDTO" Value="@Search" SearchFunc="@SearchAsync" ValueChanged="@OnResultSelected" ToStringFunc="@(x => x?.Description)" ResetValueOnEmptyText="true" 
-                 Placeholder="Search for an item, type, or collection..." DebounceInterval="500" FullWidth="false" Dense="true" Disabled="State.IsPrerendering"
-                 Variant="MudBlazor.Variant.Text" AdornmentIcon="fas fa-fw fa-search ml-2" IconSize="MudBlazor.Size.Small" Class="mud-input-no-frills ma-0 px-4" Style="max-width: 350px">
-    <ItemTemplate Context="item">
-        <div class="d-flex algin-center">
-            <img src="@item.IconUrl" class="mr-2" style="width:2em; height:2em" />
-            <MudText Class="my-1">@item.Description</MudText>
-            <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Secondary" Size="MudBlazor.Size.Small" Class="ml-2">@item.Type</MudChip>
-        </div>
-    </ItemTemplate>
-    <ItemSelectedTemplate Context="item">
-        <div class="d-flex algin-center">
-            <img src="@item.IconUrl" class="mr-2" style="width:2em; height:2em" />
-            <MudText Class="my-1">@item.Description</MudText>
-            <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Secondary" Size="MudBlazor.Size.Small" Class="ml-2">@item.Type</MudChip>
-        </div>
-    </ItemSelectedTemplate>
-</MudAutocomplete>
+<div class="px-4" style="min-width: 350px; max-width: 250px">
+    <MudAutocomplete T="SearchResultDTO" Value="@Search" SearchFunc="@SearchAsync" ValueChanged="@((x) => OnActionSelected(x.Type, x.Url, x.Description))" ToStringFunc="@(x => x?.Description)" ResetValueOnEmptyText="true"
+                     Placeholder="Search for an item, type, or collection..." DebounceInterval="500" FullWidth="false" Dense="true" Disabled="State.IsPrerendering"
+                     Variant="MudBlazor.Variant.Text" AdornmentIcon="fas fa-fw fa-search ml-2" IconSize="MudBlazor.Size.Small" Class="mud-input-no-frills ma-0">
+        <ItemTemplate Context="item">
+            <div class="d-flex algin-center">
+                <img src="@item.IconUrl" class="mr-2" style="width:2em; height:2em" />
+                <MudText Class="no-wrap my-1">@item.Description</MudText>
+                <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Secondary" Size="MudBlazor.Size.Small" Class="no-wrap ml-2">@item.Type</MudChip>
+            </div>
+        </ItemTemplate>
+        <ItemSelectedTemplate Context="item">
+            <div class="d-flex algin-center">
+                <img src="@item.IconUrl" class="mr-2" style="width:2em; height:2em" />
+                <MudText Class="no-wrap my-1">@item.Description</MudText>
+                <MudChip Variant="MudBlazor.Variant.Text" Color="MudBlazor.Color.Secondary" Size="MudBlazor.Size.Small" Class="no-wrap ml-2">@item.Type</MudChip>
+            </div>
+        </ItemSelectedTemplate>
+    </MudAutocomplete>
+</div>
+@if (PinnedActions?.Any() == true)
+{
+    <MudContainer Class="d-flex align-center justify-start scroll-x scrollbar-hidden pa-0">
+        @foreach (var pinnedActions in PinnedActions)
+        {
+            <div class="d-flex algin-center hover-darken pa-2" onclick="@(() => OnActionSelected(pinnedActions.Type, pinnedActions.Url, pinnedActions.Description))">
+                <img src="@pinnedActions.IconUrl" class="mr-2" style="width:2em; height:2em" />
+                <MudText Class="no-wrap my-1">@pinnedActions.Description</MudText>
+            </div>
+        }
+    </MudContainer>
+}
 
 @code {
 
     private SearchResultDTO Search;
+
+    private IEnumerable<PinnedActionManager.Action> PinnedActions { get; set; }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        PinnedActionManager.PinnedActionsChanged += (actions) => {
+            PinnedActions = actions;
+            StateHasChanged();
+        };
+    }
+
+    protected override async Task OnLoadStateAsync()
+    {
+        PinnedActions = await RestoreFromStateOrLoad(nameof(PinnedActions), 
+            () => PinnedActionManager.ListPinnedActions()
+        );
+    }
+
+    protected override Task OnPersistStateAsync()
+    {
+        PersistToState(nameof(PinnedActions), PinnedActions);
+        return Task.CompletedTask;
+    }
 
     private async Task<IEnumerable<SearchResultDTO>> SearchAsync(string value)
     {
@@ -51,17 +91,17 @@
         }
     }
 
-    private void OnResultSelected(SearchResultDTO result)
+    private async Task OnActionSelected(string type, string url, string description)
     {
         Search = null;
-        switch (result.Type)
+        switch (type)
         {
             case "Type":
                 Dialogs.Show<ViewItemListDialog>(null, parameters: new DialogParameters()
                 {
-                    ["ListName"] = $"All {result.Description.Pluralise()}",
-                    ["ListUrl"] = result.Url,
-                    ["DemandUrl"] = $"api/item/type/{result.Description}/demand",
+                    ["ListName"] = $"All {description.Pluralise()}",
+                    ["ListUrl"] = url,
+                    ["DemandUrl"] = $"api/item/type/{description}/demand",
                     ["SortBy"] = nameof(ItemDescriptionWithPriceDTO.TimeAccepted),
                     ["SortDirection"] = MudBlazor.SortDirection.Descending
                 });
@@ -70,16 +110,16 @@
             case "Collection":
                 Dialogs.Show<ViewItemCollectionDialog>(null, parameters: new DialogParameters()
                 {
-                    ["CollectionName"] = $"{result.Description} Collection",
-                    ["CollectionUrl"] = result.Url
+                    ["CollectionName"] = $"{description} Collection",
+                    ["CollectionUrl"] = url
                 });
                 break;
 
             case "Item":
                 Dialogs.Show<ViewItemDetailsDialog>(null, parameters: new DialogParameters()
                 {
-                    ["ItemName"] = result.Description,
-                    ["ItemUrl"] = result.Url
+                    ["ItemName"] = description,
+                    ["ItemUrl"] = url
                 });
                 break;
         }

--- a/SCMM.Web.Client/Shared/Components/SearchBar.razor
+++ b/SCMM.Web.Client/Shared/Components/SearchBar.razor
@@ -12,7 +12,7 @@
 
 <div class="px-4" style="min-width: 350px; max-width: 250px">
     <MudAutocomplete T="SearchResultDTO" Value="@Search" SearchFunc="@SearchAsync" ValueChanged="@((x) => OnActionSelected(x.Type, x.Url, x.Description))" ToStringFunc="@(x => x?.Description)" ResetValueOnEmptyText="true"
-                     Placeholder="Search for an item, type, or collection..." DebounceInterval="500" FullWidth="false" Dense="true" Disabled="State.IsPrerendering"
+                     Placeholder="Search the website for..." DebounceInterval="500" FullWidth="false" Dense="true" Disabled="State.IsPrerendering"
                      Variant="MudBlazor.Variant.Text" AdornmentIcon="fas fa-fw fa-search ml-2" IconSize="MudBlazor.Size.Small" Class="mud-input-no-frills ma-0">
         <ItemTemplate Context="item">
             <div class="d-flex algin-center">
@@ -121,6 +121,10 @@
                     ["ItemName"] = description,
                     ["ItemUrl"] = url
                 });
+                break;
+
+            case "Store":
+                NavigationManager.NavigateTo(url);
                 break;
         }
     }

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemCollectionDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemCollectionDialog.razor
@@ -3,6 +3,7 @@
 @inherits ResponsiveDialog
 @inject ILogger<ViewItemCollectionDialog> Logger
 @inject ISnackbar Snackbar
+@inject PinnedActionManager PinnedActionManager
 @inject HttpClient Http
 @inject AppState State
 
@@ -14,7 +15,7 @@
         } 
         else
         {
-            <div class="d-flex mr-4">
+            <div class="d-flex align-start mr-4">
                 @if (!String.IsNullOrEmpty(Collection.CreatorAvatarUrl))
                 {
                     <MudTooltip Text="@Collection.CreatorName">
@@ -36,6 +37,14 @@
                     }
                 </div>
                 <MudSpacer />
+                @if (Collection != null && PinnedAction != null)
+                {
+                    <MudToggleIconButton Toggled="IsActionPinned" ToggledChanged="TogglePinnedAction"
+                                         Title="Bookmark this item collection" ToggledTitle="Remove this bookmark"
+                                         Icon="far fa-bookmark" ToggledIcon="fas fa-bookmark"
+                                         Size="MudBlazor.Size.Small" ToggledSize="MudBlazor.Size.Small"
+                                         Class="ma-1 ml-4 mr-0" DisableRipple="true" Disabled="@State.IsPrerendering" />
+                }
                 <MudMenu AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft" 
                          Dense="true" Class="hover-darken align-self-start mx-4 " title="Change sort order">
                     <ActivatorContent>
@@ -126,6 +135,10 @@
 
     private ItemCollectionDTO Collection { get; set; }
     
+    private PinnedActionManager.Action PinnedAction { get; set; }
+
+    private bool IsActionPinned { get; set; }
+
     protected override void OnConfigure(ResponsiveDialogOptions options)
     {
         options.FullscreenBreakpoint = MudBlazor.Breakpoint.Sm;
@@ -141,6 +154,16 @@
         try
         {
             Collection = await Http.GetFromJsonWithDefaultsAsync<ItemCollectionDTO>(CollectionUrl);
+            PinnedAction = new PinnedActionManager.Action()
+            {
+                Type = "Collection",
+                Url = CollectionUrl,
+                IconUrl = Collection.AcceptedItems.FirstOrDefault()?.IconUrl ?? Collection.CreatorAvatarUrl,
+                Description = Collection.Name,
+            };
+
+            IsActionPinned = await PinnedActionManager.IsPinned(PinnedAction);
+
             Dialog.StateHasChanged();
         }
         catch (Exception ex)
@@ -165,5 +188,18 @@
         }
 
         return items;
+    }
+
+    private async Task TogglePinnedAction(bool pinned)
+    {
+        IsActionPinned = !pinned;
+        if (pinned)
+        {
+            await PinnedActionManager.PinAction(PinnedAction);
+        }
+        else
+        {
+            await PinnedActionManager.UnpinAction(PinnedAction);
+        }
     }
 }

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemDetailsDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemDetailsDialog.razor
@@ -3,12 +3,24 @@
 @inherits ResponsiveDialog
 @inject ILogger<ViewItemDetailsDialog> Logger
 @inject ISnackbar Snackbar
+@inject PinnedActionManager PinnedActionManager
 @inject HttpClient Http
 @inject AppState State
 
 <MudDialog>
     <TitleContent>
-        <MudText Typo="MudBlazor.Typo.h6">@ItemName Details</MudText>
+        <div class="d-flex align-start mr-4">
+            <MudText Typo="MudBlazor.Typo.h6">@ItemName Details</MudText>
+            <MudSpacer />
+            @if (Item != null && PinnedAction != null)
+            {
+                <MudToggleIconButton Toggled="IsActionPinned" ToggledChanged="TogglePinnedAction"
+                                     Title="Bookmark this item" ToggledTitle="Remove this bookmark"
+                                     Icon="far fa-bookmark" ToggledIcon="fas fa-bookmark"
+                                     Size="MudBlazor.Size.Small" ToggledSize="MudBlazor.Size.Small"
+                                     Class="ma-1 mx-4" DisableRipple="true" Disabled="@State.IsPrerendering" />
+            }
+        </div>
     </TitleContent>
     <DialogContent>
         @if (Item == null)
@@ -33,7 +45,11 @@
     public string ItemUrl { get; set; }
 
     private ItemDetailedDTO Item { get; set; }
-    
+
+    private PinnedActionManager.Action PinnedAction { get; set; }
+
+    private bool IsActionPinned { get; set; }
+
     protected override void OnConfigure(ResponsiveDialogOptions options)
     {
         options.FullscreenBreakpoint = MudBlazor.Breakpoint.Md;
@@ -49,12 +65,35 @@
         try
         {
             Item = await Http.GetFromJsonWithDefaultsAsync<ItemDetailedDTO>(ItemUrl);
+            PinnedAction = new PinnedActionManager.Action()
+            {
+                Type = "Item",
+                Url = ItemUrl,
+                IconUrl = Item?.IconUrl,
+                Description = ItemName,
+            };
+
+            IsActionPinned = await PinnedActionManager.IsPinned(PinnedAction);
+
             Dialog.StateHasChanged();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, $"Error loading the item details");
             Snackbar.Add($"Unable to load item details. {ex.Message}", MudBlazor.Severity.Error);
+        }
+    }
+
+    private async Task TogglePinnedAction(bool pinned)
+    {
+        IsActionPinned = !pinned;
+        if (pinned)
+        {
+            await PinnedActionManager.PinAction(PinnedAction);
+        }
+        else
+        {
+            await PinnedActionManager.UnpinAction(PinnedAction);
         }
     }
 

--- a/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemListDialog.razor
+++ b/SCMM.Web.Client/Shared/Dialogs/Items/ViewItemListDialog.razor
@@ -3,6 +3,7 @@
 @inherits ResponsiveDialog
 @inject ILogger<ViewItemListDialog> Logger
 @inject ISnackbar Snackbar
+@inject PinnedActionManager PinnedActionManager
 @inject HttpClient Http
 @inject DocumentManager Document
 @inject AppState State
@@ -18,9 +19,17 @@
                         <span> (@List.Items.Length) </span>
                     }
                 </MudText>
+                <MudSpacer />
+                @if (List != null && PinnedAction != null)
+                {
+                    <MudToggleIconButton Toggled="IsActionPinned" ToggledChanged="TogglePinnedAction"
+                                         Title="Bookmark this list" ToggledTitle="Remove this bookmark"
+                                         Icon="far fa-bookmark" ToggledIcon="fas fa-bookmark"
+                                         Size="MudBlazor.Size.Small" ToggledSize="MudBlazor.Size.Small"
+                                         Class="ma-1 ml-4 mr-0" DisableRipple="true" Disabled="@State.IsPrerendering" />
+                }
                 @if (List?.Items?.Any() == true)
                 {
-                    <MudSpacer />
                     <MudMenu AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft"
                              Dense="true" Class="@($"hover-darken mx-4 {(IsMediaSize(Breakpoint.SmAndDown) ? "mr-8" : null)}")" title="Change sort order">
                         <ActivatorContent>
@@ -217,6 +226,10 @@
     private ItemGroupDemandDTO Demand { get; set; }
 
     private string Filter { get; set; }
+    
+    private PinnedActionManager.Action PinnedAction { get; set; }
+
+    private bool IsActionPinned { get; set; }
 
     protected override void OnConfigure(ResponsiveDialogOptions options)
     {
@@ -234,6 +247,16 @@
         {
             List = await Http.GetFromJsonWithDefaultsAsync<PaginatedResult<ItemDescriptionWithPriceDTO>>(ListUrl);
             ListFilteredAndSorted = GetFilteredAndSortedItems(List.Items).ToArray();
+            PinnedAction = new PinnedActionManager.Action()
+            {
+                Type = "List",
+                Url = ListUrl,
+                IconUrl = List?.Items?.FirstOrDefault()?.IconUrl,
+                Description = ListName,
+            };
+
+            IsActionPinned = await PinnedActionManager.IsPinned(PinnedAction);
+
             Dialog.StateHasChanged();
             StateHasChanged();
 
@@ -296,4 +319,18 @@
 
         return items;
     }
+    
+    private async Task TogglePinnedAction(bool pinned)
+    {
+        IsActionPinned = !pinned;
+        if (pinned)
+        {
+            await PinnedActionManager.PinAction(PinnedAction);
+        }
+        else
+        {
+            await PinnedActionManager.UnpinAction(PinnedAction);
+        }
+    }
+
 }

--- a/SCMM.Web.Client/Shared/Layout/AppBarNotificationControls.razor
+++ b/SCMM.Web.Client/Shared/Layout/AppBarNotificationControls.razor
@@ -1,9 +1,10 @@
 ﻿@using SCMM.Web.Data.Models.UI.System
+@using Blazored.LocalStorage
 @using Markdig
 @inherits PersistentComponent
 @inject ILogger<AppBarAppControls> Logger
 @inject ISnackbar Snackbar
-@inject ICookieManager CookieManager
+@inject ILocalStorageService LocalStorage
 @inject ISystemService SystemService
 @inject NavigationManager NavigationManager
 @inject ExternalNavigationManager ExternalNavigationManager
@@ -34,7 +35,7 @@
                     {
                         <MudStack>
                             <MudText Typo="Typo.h6" Color="Color.Default">
-                                <span class="no-wrap">@((DateTimeOffset.Now - message.Timestamp).ToDurationString(maxGranularity: 1, suffix: "ago"))</span>
+                                <span class="no-wrap"><i class="fa fa-fw fa-rss mr-2"></i> @((DateTimeOffset.Now - message.Timestamp).ToDurationString(maxGranularity: 1, suffix: "ago"))</span>
                             </MudText>
                             <MudText Typo="Typo.body1" Color="Color.Secondary">
                                 <span class="notification-content">
@@ -81,7 +82,8 @@
     {
         NotificationsLastViewedOn = await RestoreFromStateOrLoad(nameof(NotificationsLastViewedOn), async () =>
         {
-            return DateTimeOffset.FromUnixTimeMilliseconds(await CookieManager.GetAsync<long>("notifications-last-viewed", DateTimeOffset.MinValue.ToUnixTimeMilliseconds()));
+            var lastViewed = await LocalStorage.GetItemAsync<long>("NotificationsLastViewed");
+            return DateTimeOffset.FromUnixTimeMilliseconds(lastViewed > 0 ? lastViewed : DateTimeOffset.MinValue.ToUnixTimeMilliseconds());
         });
         Notifications = await RestoreFromStateOrLoad(nameof(Notifications), async () =>
         {
@@ -104,13 +106,13 @@
         return Task.CompletedTask;
     }
 
-    private void OnToggleMenu(bool toggle)
+    private async Task OnToggleMenu(bool toggle)
     {
         IsOpen = toggle;
         if (IsOpen)
         {
             NotificationsLastViewedOn = DateTimeOffset.Now;
-            CookieManager.Set("notifications-last-viewed", NotificationsLastViewedOn.ToUnixTimeMilliseconds(), 365);
+            await LocalStorage.SetItemAsync("NotificationsLastViewed", NotificationsLastViewedOn.ToUnixTimeMilliseconds());
         }
     }
 

--- a/SCMM.Web.Client/Shared/Layout/AppBarProfileControls.razor
+++ b/SCMM.Web.Client/Shared/Layout/AppBarProfileControls.razor
@@ -15,8 +15,8 @@
                 {
                     <MudHidden Breakpoint="MudBlazor.Breakpoint.MdAndUp" Invert="true">
                         <div class="d-flex flex-column">
-                            <MudText Typo="@MudBlazor.Typo.caption" Color="@MudBlazor.Color.Secondary" Class="mr-2"><small>Inventory Value</small></MudText>
-                            <MudText Typo="@MudBlazor.Typo.subtitle2" Color="@MudBlazor.Color.Default" Class="mr-2 mt-n1">
+                            <MudText Typo="@MudBlazor.Typo.caption" Color="@MudBlazor.Color.Secondary" Class="no-wrap mr-2"><small>Inventory Value</small></MudText>
+                            <MudText Typo="@MudBlazor.Typo.subtitle2" Color="@MudBlazor.Color.Default" Class="no-wrap mr-2 mt-n1">
                                 <span title="Current market value of your inventory">@State.Currency?.ToPriceString(InventoryTotals.MarketValue)</span>
                             </MudText>
                         </div>

--- a/SCMM.Web.Client/Shared/Navigation/PinnedActionManager.cs
+++ b/SCMM.Web.Client/Shared/Navigation/PinnedActionManager.cs
@@ -1,0 +1,55 @@
+﻿using Blazored.LocalStorage;
+namespace SCMM.Web.Client.Shared.Navigation;
+
+public class PinnedActionManager
+{
+    private const string PinnedActionsKey = "PinnedActions";
+
+    private readonly ILocalStorageService _localStorage;
+
+    public PinnedActionManager(ILocalStorageService localStorage)
+    {
+        _localStorage = localStorage;
+    }
+
+    public async Task<IEnumerable<Action>> ListPinnedActions()
+    {
+        return (await _localStorage.GetItemAsync<Action[]>(PinnedActionsKey) ?? Array.Empty<Action>()).ToArray();
+    }
+
+    public async Task PinAction(Action action)
+    {
+        var newActions = (await ListPinnedActions()).Append(action).ToArray();
+        await _localStorage.SetItemAsync(PinnedActionsKey, newActions);
+        PinnedActionsChanged?.Invoke(newActions);
+    }
+
+    public async Task UnpinAction(Action action)
+    {
+        var newActions = (await ListPinnedActions()).Where(a => a.Id != action.Id).ToArray();
+        await _localStorage.SetItemAsync(PinnedActionsKey, newActions);
+        PinnedActionsChanged?.Invoke(newActions);
+    }
+
+    public async Task<bool> IsPinned(Action action)
+    {
+        return (await ListPinnedActions()).Any(a => a.Id == action.Id);
+    }
+
+    public delegate void PinnedActionsChangedHandler(IEnumerable<Action> pinnedActions);
+
+    public PinnedActionsChangedHandler PinnedActionsChanged;
+
+    public class Action
+    {
+        public string Id => $"{Type}:{Url}";
+
+        public string Type { get; set; }
+
+        public string Url { get; set; }
+
+        public string IconUrl { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/SCMM.Web.Client/wwwroot/css/scmm.css
+++ b/SCMM.Web.Client/wwwroot/css/scmm.css
@@ -27,6 +27,10 @@
     overflow-y: scroll;
 }
 
+.scrollbar-hidden {
+    scrollbar-width: none;
+}
+
 .full-width {
     width: 100% !important;
 }

--- a/SCMM.Web.Server/API/Controllers/SearchController.cs
+++ b/SCMM.Web.Server/API/Controllers/SearchController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using SCMM.Shared.API.Extensions;
 using SCMM.Shared.Data.Models.Extensions;
+using SCMM.Steam.Data.Models;
 using SCMM.Steam.Data.Models.Extensions;
 using SCMM.Steam.Data.Store;
 using SCMM.Web.Data.Models.UI.Search;
@@ -90,6 +91,17 @@ namespace SCMM.Web.Server.API.Controllers
                 })
                 .ToListAsync();
 
+            var storeResults = await _db.SteamItemStores
+                .Where(x => x.AppId == app.Guid)
+                .Select(x => new
+                {
+                    Id = x.Id,
+                    Start = x.Start,
+                    Name = x.Name,
+                    IconUrl = x.ItemsThumbnailUrl
+                })
+                .ToListAsync();
+
             results.AddRange(
                 itemTypeResults.Select(x => new SearchResultDTO()
                 {
@@ -117,6 +129,16 @@ namespace SCMM.Web.Server.API.Controllers
                     IconUrl = x.IconUrl,
                     Description = x.Name,
                     Url = $"/api/item/{x.ClassId}"
+                })
+            );
+
+            results.AddRange(
+                storeResults.Select(x => new SearchResultDTO()
+                {
+                    Type = "Store",
+                    IconUrl = x.IconUrl,
+                    Description = String.IsNullOrEmpty(x.Name) ? x.Start?.ToString("yyyy MMMM d") : x.Name,
+                    Url = $"/store/{x.Id}"
                 })
             );
 

--- a/SCMM.Web.Server/API/Controllers/SearchController.cs
+++ b/SCMM.Web.Server/API/Controllers/SearchController.cs
@@ -144,7 +144,8 @@ namespace SCMM.Web.Server.API.Controllers
 
             return Ok(results
                 .Where(x => words.Any(y => x.Description.Contains(y, StringComparison.InvariantCultureIgnoreCase)))
-                .OrderBy(x => x.Description.LevenshteinDistanceFrom(query))
+                .OrderByDescending(x => words.Any(y => y.Equals(x.Type, StringComparison.InvariantCultureIgnoreCase)))
+                .ThenBy(x => x.Description.LevenshteinDistanceFrom(query))
                 .Take(10)
                 .ToArray()
             );


### PR DESCRIPTION
- Resolve CodeQL findings
- When searching, prioritise results that match the type being described (e.g. "halloween store" will show "store" results first)
- App bar notifications "last viewed" timestamp is now stored in local storage instead of as a cookie
- Add support for pinning "actions" to the app bar; supported actions are:
  - Items
  - Item collections
  - Item types
  - Item lists
  - Item stores

![image](https://github.com/Steam-Community-Market-Manager/SCMM/assets/123988/8fd1224e-6656-4174-ba57-d1e656970f27)

![image](https://github.com/Steam-Community-Market-Manager/SCMM/assets/123988/983c122f-aeaa-4653-ba8a-7657241a777c)
